### PR TITLE
Print warnings for too large decomposition level values

### DIFF
--- a/src/ptwt/matmul_transform.py
+++ b/src/ptwt/matmul_transform.py
@@ -7,6 +7,7 @@ in Strang Nguyen (p. 32), as well as the description
 of boundary filters in "Ripples in Mathematics" section 10.3 .
 """
 # Created by moritz (wolter@cs.uni-bonn.de) at 14.04.20
+import sys
 from typing import List, Optional, Union
 
 import numpy as np
@@ -253,8 +254,16 @@ class MatrixWavedec(object):
 
         filt_len = self.wavelet.dec_len
         curr_length = length
-        for _ in range(1, self.level + 1):
+        for curr_level in range(1, self.level + 1):
             if curr_length < filt_len:
+                sys.stderr.write(
+                    f"Warning: The selected number of decomposition levels {self.level}"
+                    f" is too large for the given input size {length}. At level "
+                    f"{curr_level}, the current signal length {curr_length} is "
+                    f"smaller than the filter length {filt_len}. Therefore, the "
+                    "transformation is only computed up to the decomposition level "
+                    f"{curr_level-1}.\n"
+                )
                 break
 
             if curr_length % 2 != 0:
@@ -499,8 +508,16 @@ class MatrixWaverec(object):
         curr_length = length
         if self.level is None:
             raise ValueError
-        for _ in range(self.level):
+        for curr_level in range(1, self.level + 1):
             if curr_length < filt_len:
+                sys.stderr.write(
+                    f"Warning: The selected number of decomposition levels {self.level}"
+                    f" is too large for the given input size {length}. At level "
+                    f"{curr_level}, the current signal length {curr_length} is "
+                    f"smaller than the filter length {filt_len}. Therefore, the "
+                    "transformation is only computed up to the decomposition level "
+                    f"{curr_level-1}.\n"
+                )
                 break
 
             if curr_length % 2 != 0:

--- a/src/ptwt/matmul_transform_2d.py
+++ b/src/ptwt/matmul_transform_2d.py
@@ -3,6 +3,7 @@
 This module uses boundary filters to minimize padding.
 """
 # Written by moritz ( @ wolter.tech ) in 2021
+import sys
 from typing import List, Optional, Tuple, Union, cast
 
 import numpy as np
@@ -323,9 +324,17 @@ class MatrixWavedec2d(object):
 
         filt_len = self.wavelet.dec_len
         current_height, current_width = height, width
-        for _ in range(1, self.level + 1):
+        for curr_level in range(1, self.level + 1):
             if current_height < filt_len or current_width < filt_len:
                 # we have reached the max decomposition depth.
+                sys.stderr.write(
+                    f"Warning: The selected number of decomposition levels {self.level}"
+                    f" is too large for the given input shape ({height}, {width}). At "
+                    f"level {curr_level}, at least one of the current signal height and"
+                    f" width ({current_height}, {current_width}) is smaller than the "
+                    f"filter length {filt_len}. Therefore, the transformation is only "
+                    f"computed up to the decomposition level {curr_level-1}.\n"
+                )
                 break
             # the conv matrices require even length inputs.
             current_height, current_width, pad_tuple = _matrix_pad_2d(
@@ -587,7 +596,18 @@ class MatrixWaverec2d(object):
         self.padded = False
         if self.level is None:
             raise ValueError
-        for _ in range(0, self.level):
+        filt_len = self.wavelet.rec_len
+        for curr_level in range(1, self.level + 1):
+            if current_height < filt_len or current_width < filt_len:
+                sys.stderr.write(
+                    f"Warning: The selected number of decomposition levels {self.level}"
+                    f" is too large for the given input shape ({height}, {width}). At "
+                    f"level {curr_level}, at least one of the current signal height and"
+                    f" width ({current_height}, {current_width}) is smaller than the "
+                    f"filter length {filt_len}. Therefore, the transformation is only "
+                    f"computed up to the decomposition level {curr_level-1}.\n"
+                )
+                break
             current_height, current_width, pad_tuple = _matrix_pad_2d(
                 current_height, current_width
             )


### PR DESCRIPTION
If a number of decomposition levels is selected that is too large for the transformed signal, we stop the decomposition at the maximum decomposition level.
In these cases, this pull request adds a warning message to the user since the output of the transform deviates from the expected (but incompatible) number of levels.