### PR TITLE
Make wavelet packet transform object based

### DIFF
--- a/src/ptwt/matmul_transform_2d.py
+++ b/src/ptwt/matmul_transform_2d.py
@@ -139,7 +139,7 @@ def construct_boundary_a2d(
     """
     wavelet = _as_wavelet(wavelet)
     a = _construct_a_2d(wavelet, height, width, device, dtype=dtype)
-    orth_a = orthogonalize(a, wavelet.dec_len ** 2, method=boundary)
+    orth_a = orthogonalize(a, wavelet.dec_len ** 2, method=boundary)  # noqa: BLK100
     return orth_a
 
 
@@ -172,7 +172,7 @@ def construct_boundary_s2d(
     wavelet = _as_wavelet(wavelet)
     s = _construct_s_2d(wavelet, height, width, device, dtype=dtype)
     orth_s = orthogonalize(
-        s.transpose(1, 0), wavelet.rec_len ** 2, method=boundary
+        s.transpose(1, 0), wavelet.rec_len ** 2, method=boundary  # noqa: BLK100
     ).transpose(1, 0)
     return orth_s
 

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -321,7 +321,7 @@ if __name__ == "__main__":
         torch.from_numpy(np.mean(face, axis=-1).astype(np.float32)), 0
     )
     pt_data = torch.cat([pt_data, pt_data], 0)
-    ptwt_wp_tree = WaveletPacket2D(data=pt_data, wavelet=wavelet, mode="boundary")
+    ptwt_wp_tree = WaveletPacket2D(wavelet=wavelet, mode="boundary").transform(pt_data)
 
     # get the PyTorch decomposition
     count = 0

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -26,7 +26,7 @@ def test_packet_harbo_lvl3():
 
     wavelet = pywt.Wavelet("unscaled Haar Wavelet", filter_bank=MyHaarFilterBank())
     data = torch.tensor(w)
-    twp = WaveletPacket(wavelet, mode="reflect").transform(data)
+    twp = WaveletPacket(data, wavelet, mode="reflect")
     nodes = twp.get_level(3)
     twp_lst = []
     for node in nodes:
@@ -76,9 +76,7 @@ def _compare_trees(
     pt_data = torch.unsqueeze(
         torch.from_numpy(np.mean(face, axis=-1).astype(np.float64)), 0
     )
-    ptwt_wp_tree = WaveletPacket2D(wavelet=wavelet, mode=ptwt_boundary).transform(
-        pt_data
-    )
+    ptwt_wp_tree = WaveletPacket2D(pt_data, wavelet=wavelet, mode=ptwt_boundary)
     # get the PyTorch decomposition
     count = 0
     img_pt = []

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -26,7 +26,7 @@ def test_packet_harbo_lvl3():
 
     wavelet = pywt.Wavelet("unscaled Haar Wavelet", filter_bank=MyHaarFilterBank())
     data = torch.tensor(w)
-    twp = WaveletPacket(data, wavelet, mode="reflect")
+    twp = WaveletPacket(wavelet, mode="reflect").transform(data)
     nodes = twp.get_level(3)
     twp_lst = []
     for node in nodes:
@@ -76,7 +76,9 @@ def _compare_trees(
     pt_data = torch.unsqueeze(
         torch.from_numpy(np.mean(face, axis=-1).astype(np.float64)), 0
     )
-    ptwt_wp_tree = WaveletPacket2D(data=pt_data, wavelet=wavelet, mode=ptwt_boundary)
+    ptwt_wp_tree = WaveletPacket2D(wavelet=wavelet, mode=ptwt_boundary).transform(
+        pt_data
+    )
     # get the PyTorch decomposition
     count = 0
     img_pt = []


### PR DESCRIPTION
### Idea
The main idea of this change is to make the wavelet packet transform behave like a transform object to make it easier to reuse it for a sequence of similar transformations. This is motivated by the use case of transforming a full dataset, where each element of the dataset has the same shape, so one could reuse the (matrix-based) packet transforms.

### Interface change

This would change the call structure from
```python
# old call structure
packets = ptwt.WaveletPacket(input_data, wavelet, mode)
```
to
```python
# just the transformation initialization, no decomposition yet
packets = ptwt.WaveletPacket(wavelet, mode)
# now decompose input data
packets.transform(foo_data) # packets now contains decomposition of foo_data
packets.transform(bar_data) # packets now contains decomposition of bar_data
```
To simplify the notation, one can also write the following to initialize and decompose in one line.
```python
packets = ptwt.WaveletPacket(wavelet, mode).transform(input_data)
```
### Further changes
This also cleans up the packets module a bit. Besides that, the following is new/changed:
* now, we also 'cache' the dwt matrix transformation objects in the 1d case
* added a few more key-word args to allow changing the behaviour of the internal dwt

### Remarks
This is a breaking change regarding the call structure. We could address this by overloading the constructor with a backwards-compatible interface. Ideas?

However, I'm not sure whether this breaking change is needed or worth it. We could also address this by making the constructor call `transform` internally and then using `transform` simply for recomputing a decomposition for different data. That would be backwards and `pywt` compatible, but one would need to have a data instance at creation time of the object (I'm positive there is a good workaround regarding this).
