### PR TITLE
Wavelet-Packet Dimension patch

### DIFF
--- a/src/ptwt/conv_transform.py
+++ b/src/ptwt/conv_transform.py
@@ -207,8 +207,10 @@ def wavedec2(
     Args:
         data (torch.Tensor): The input data tensor of shape
             [batch_size, 1, height, width].
+            2d inputs are interpreted as [height, width],
+            3d inputs are interpreted as [batch_size, height, width].
         wavelet (Wavelet or str): A pywt wavelet compatible object or
-                the name of a pywt wavelet.
+            the name of a pywt wavelet.
         level (int): The number of desired scales.
             Defaults to None.
         mode (str): The padding mode, i.e. zero or reflect.
@@ -233,6 +235,11 @@ def wavedec2(
                                          level=2, mode="constant")
 
     """
+    if data.dim() == 2:
+        data = data.unsqueeze(0).unsqueeze(0)
+    elif data.dim() == 3:
+        data = data.unsqueeze(1)
+
     wavelet = _as_wavelet(wavelet)
     dec_lo, dec_hi, _, _ = get_filter_tensors(
         wavelet, flip=True, device=data.device, dtype=data.dtype
@@ -373,10 +380,10 @@ def wavedec(
                          mode='zero', level=2)
 
     """
-    if len(data.shape) == 1:
+    if data.dim() == 1:
         # assume time series
         data = data.unsqueeze(0).unsqueeze(0)
-    elif len(data.shape) == 2:
+    elif data.dim() == 2:
         # assume batched time series
         data = data.unsqueeze(1)
 

--- a/src/ptwt/matmul_transform.py
+++ b/src/ptwt/matmul_transform.py
@@ -294,17 +294,24 @@ class MatrixWavedec(object):
 
         Args:
             input_signal (torch.Tensor): Batched input data [batch_size, time],
-                  should be of even length.
+                should be of even length. 1d inputs are interpreted as [time].
 
         Returns:
             List[torch.Tensor]: A list with the coefficients for each scale.
 
         Raises:
-            ValueError: If the decomposition level is not a positive integer.
+            ValueError: If the decomposition level is not a positive integer
+                or if the input signal has not the expected shape.
         """
-        if len(input_signal.shape) == 1:
+        if input_signal.dim() == 1:
             # assume time series
             input_signal = input_signal.unsqueeze(0)
+        elif input_signal.dim() != 2:
+            raise ValueError(
+                f"Invalid input tensor shape {input_signal.size()}. "
+                "The input signal is expected to be of the form "
+                "[batch_size, length]."
+            )
 
         if input_signal.shape[-1] % 2 != 0:
             # odd length input

--- a/src/ptwt/matmul_transform_2d.py
+++ b/src/ptwt/matmul_transform_2d.py
@@ -383,20 +383,31 @@ class MatrixWavedec2d(object):
 
         Args:
             input_signal (torch.Tensor): An input signal of shape
-                [batch_size, height, width]
+                [batch_size, height, width].
+                2d inputs are interpreted as [height, width].
+                Inputs of the form [batch_size, 1, height, width] are squeezed.
 
         Returns:
             (list): The resulting coefficients per level stored in
             a pywt style list.
 
         Raises:
-            ValueError: If the decomposition level is not a positive integer.
+            ValueError: If the decomposition level is not a positive integer
+                or if the input signal has not the expected shape.
         """
-        if input_signal.shape[1] == 1:
-            input_signal = input_signal.squeeze(1)
-
-        if len(input_signal.shape) == 2:
+        if input_signal.dim() == 2:
+            # add batch dim to unbatched input
             input_signal = input_signal.unsqueeze(0)
+        elif input_signal.dim() == 4 and input_signal.size(1) == 1:
+            # we assume the shape [batch_size, color_channels, height, width]
+            # and squeeze the single color channel
+            input_signal = input_signal.squeeze(1)
+        elif input_signal.dim() != 3:
+            raise ValueError(
+                f"Invalid input tensor shape {input_signal.size()}. "
+                "The input signal is expected to be of the form "
+                "[batch_size, height, width]."
+            )
 
         batch_size, height, width = input_signal.shape
 

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -232,9 +232,6 @@ class WaveletPacket2D(BaseDict):
             raise AssertionError
         self.data[path] = torch.squeeze(data, 1)
         if level < self.max_level:
-            # resa, (resh, resv, resd) = self.wavedec2(
-            #    data, self.wavelet, level=1, mode=self.mode
-            # )
             result_a, (result_h, result_v, result_d) = self._get_wavedec(
                 data.shape[-2:]
             )(data)
@@ -248,7 +245,6 @@ class WaveletPacket2D(BaseDict):
             )
         else:
             self.data[path] = torch.squeeze(data, 1)
-            # self.data[path] = data
 
 
 def get_freq_order(level: int) -> List[List[Tuple[str, ...]]]:

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -121,7 +121,8 @@ class WaveletPacket(BaseDict):
     ):
         if not self.max_level:
             raise AssertionError
-        self.data[path] = torch.squeeze(data, 1)
+
+        self.data[path] = data
         if level < self.max_level:
             res_lo, res_hi = self._get_wavedec(data.shape[-1])(data)
             return (
@@ -129,7 +130,7 @@ class WaveletPacket(BaseDict):
                 self._recursive_dwt(res_hi, level + 1, path + "d"),
             )
         else:
-            self.data[path] = torch.squeeze(data, 1)
+            self.data[path] = data
 
 
 class WaveletPacket2D(BaseDict):
@@ -229,7 +230,7 @@ class WaveletPacket2D(BaseDict):
     ):
         if not self.max_level:
             raise AssertionError
-        self.data[path] = data
+        self.data[path] = torch.squeeze(data, 1)
         if level < self.max_level:
             # resa, (resh, resv, resd) = self.wavedec2(
             #    data, self.wavelet, level=1, mode=self.mode
@@ -247,10 +248,13 @@ class WaveletPacket2D(BaseDict):
             )
         else:
             self.data[path] = torch.squeeze(data, 1)
+            # self.data[path] = data
 
 
 def get_freq_order(level: int) -> List[List[Tuple[str, ...]]]:
     """Get the frequency order for a given packet decomposition level.
+
+    Use this code to create two-dimensional frequency orderings.
 
     Args:
         level (int): The number of decomposition scales.

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -114,23 +114,20 @@ class WaveletPacket(BaseDict):
             ]
         return graycode_order
 
-    # ignoring missing return type, as recursive nesting is currently not supported
-    # see https://github.com/python/mypy/issues/731
-    def _recursive_dwt(  # type: ignore[no-untyped-def]
-        self, data: torch.Tensor, level: int, path: str
-    ):
+    def _recursive_dwt(self, data: torch.Tensor, level: int, path: str) -> None:
         if not self.max_level:
             raise AssertionError
+
+        # TODO: This is a workaround since the convolutional transforms insert a
+        #       squeezable dimension. We should adapt the wavedec code instead.
+        if data.dim() == 3:
+            data = data.squeeze(1)
 
         self.data[path] = data
         if level < self.max_level:
             res_lo, res_hi = self._get_wavedec(data.shape[-1])(data)
-            return (
-                self._recursive_dwt(res_lo, level + 1, path + "a"),
-                self._recursive_dwt(res_hi, level + 1, path + "d"),
-            )
-        else:
-            self.data[path] = data
+            self._recursive_dwt(res_lo, level + 1, path + "a")
+            self._recursive_dwt(res_hi, level + 1, path + "d")
 
 
 class WaveletPacket2D(BaseDict):
@@ -197,9 +194,6 @@ class WaveletPacket2D(BaseDict):
             max_level = pywt.dwt_max_level(min(data.shape[-2:]), self.wavelet.dec_len)
         self.max_level = max_level
 
-        if data.dim() == 3:
-            data = torch.unsqueeze(data, 1)
-
         self._recursive_dwt2d(data, level=0, path="")
         return self
 
@@ -223,28 +217,26 @@ class WaveletPacket2D(BaseDict):
         else:
             return partial(wavedec2, wavelet=self.wavelet, level=1, mode=self.mode)
 
-    # ignoring missing return type, as recursive nesting is currently not supported
-    # see https://github.com/python/mypy/issues/731
-    def _recursive_dwt2d(  # type: ignore[no-untyped-def]
-        self, data: torch.Tensor, level: int, path: str
-    ):
+    def _recursive_dwt2d(self, data: torch.Tensor, level: int, path: str) -> None:
         if not self.max_level:
             raise AssertionError
-        self.data[path] = torch.squeeze(data, 1)
+
+        # TODO: This is a workaround since the convolutional transforms insert a
+        #       squeezable dimension. We should adapt the wavedec2 code instead.
+        if data.dim() == 4:
+            data = data.squeeze(1)
+
+        self.data[path] = data
         if level < self.max_level:
             result_a, (result_h, result_v, result_d) = self._get_wavedec(
                 data.shape[-2:]
             )(data)
             # assert for type checking
             assert not isinstance(result_a, tuple)
-            return (
-                self._recursive_dwt2d(result_a, level + 1, path + "a"),
-                self._recursive_dwt2d(result_h, level + 1, path + "h"),
-                self._recursive_dwt2d(result_v, level + 1, path + "v"),
-                self._recursive_dwt2d(result_d, level + 1, path + "d"),
-            )
-        else:
-            self.data[path] = torch.squeeze(data, 1)
+            self._recursive_dwt2d(result_a, level + 1, path + "a")
+            self._recursive_dwt2d(result_h, level + 1, path + "h")
+            self._recursive_dwt2d(result_v, level + 1, path + "v")
+            self._recursive_dwt2d(result_d, level + 1, path + "d")
 
 
 def get_freq_order(level: int) -> List[List[Tuple[str, ...]]]:

--- a/tests/test_boundary_filters.py
+++ b/tests/test_boundary_filters.py
@@ -132,10 +132,9 @@ def test_matrix_analysis_fwt_2d_haar(size, level):
     face = np.mean(
         scipy.misc.face()[256 : (256 + size[0]), 256 : (256 + size[1])], -1
     ).astype(np.float64)
-    pt_face = torch.tensor(face)
     wavelet = pywt.Wavelet("haar")
     matrixfwt = MatrixWavedec2d(wavelet, level=level)
-    mat_coeff = matrixfwt(pt_face.unsqueeze(0))
+    mat_coeff = matrixfwt(torch.from_numpy(face))
     conv_coeff = pywt.wavedec2(face, wavelet, level=level, mode="zero")
     flat_mat_coeff = torch.cat(flatten_2d_coeff_lst(mat_coeff), -1)
     flat_conv_coeff = np.concatenate(flatten_2d_coeff_lst(conv_coeff), -1)
@@ -169,10 +168,9 @@ def test_boundary_matrix_fwt_2d(wavelet_str, size, level, separable):
     face = np.mean(
         scipy.misc.face()[256 : (256 + size[0]), 256 : (256 + size[1])], -1
     ).astype(np.float64)
-    pt_face = torch.tensor(face)
     wavelet = pywt.Wavelet(wavelet_str)
     matrixfwt = MatrixWavedec2d(wavelet, level=level, separable=separable)
-    mat_coeff = matrixfwt(pt_face.unsqueeze(0))
+    mat_coeff = matrixfwt(torch.from_numpy(face))
     matrixifwt = MatrixWaverec2d(wavelet, separable=separable)
     reconstruction = matrixifwt(mat_coeff).squeeze(0)
     # remove the padding
@@ -206,7 +204,7 @@ def test_batched_2d_matrix_fwt_ifwt(wavelet_str, level, size, separable):
     face = scipy.misc.face()[256 : (256 + size[0]), 256 : (256 + size[1])].astype(
         np.float64
     )
-    pt_face = torch.tensor(face).permute([2, 0, 1])
+    pt_face = torch.from_numpy(face).permute([2, 0, 1])
     wavelet = pywt.Wavelet(wavelet_str)
     matrixfwt = MatrixWavedec2d(wavelet, level=level, separable=separable)
     mat_coeff = matrixfwt(pt_face)
@@ -284,8 +282,7 @@ def test_matrix_transform_2d_rebuild(wavelet_str, separable):
             face = np.mean(
                 scipy.misc.face()[256 : (256 + size[0]), 256 : (256 + size[1])], -1
             ).astype(np.float64)
-            pt_face = torch.tensor(face)
-            mat_coeff = matrixfwt(pt_face.unsqueeze(0))
+            mat_coeff = matrixfwt(torch.from_numpy(face))
             reconstruction = matrixifwt(mat_coeff).squeeze(0)
             # remove the padding
             if size[0] % 2 != 0:

--- a/tests/test_convolution_fwt.py
+++ b/tests/test_convolution_fwt.py
@@ -19,30 +19,29 @@ from src.ptwt.wavelets_learnable import SoftOrthogonalWavelet
 
 def test_conv_fwt_haar_lvl2():
     """Test Haar wavelet level two conv fwt."""
-    data = [
-        1.0,
-        2.0,
-        3.0,
-        4.0,
-        5.0,
-        6.0,
-        7.0,
-        8.0,
-        9.0,
-        10.0,
-        11.0,
-        12.0,
-        13.0,
-        14.0,
-        15.0,
-        16.0,
-    ]
-    # npdata = np.array(data)
-    ptdata = torch.tensor(data).unsqueeze(0).unsqueeze(0)
-
+    data = np.array(
+        [
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+            5.0,
+            6.0,
+            7.0,
+            8.0,
+            9.0,
+            10.0,
+            11.0,
+            12.0,
+            13.0,
+            14.0,
+            15.0,
+            16.0,
+        ]
+    )
     wavelet = pywt.Wavelet("haar")
     coeffs = pywt.wavedec(data, wavelet, level=2)
-    coeffs2 = wavedec(ptdata, wavelet, level=2)
+    coeffs2 = wavedec(torch.from_numpy(data), wavelet, level=2)
     assert len(coeffs) == len(coeffs2)
 
     pywt_coeffs = np.concatenate(coeffs)
@@ -58,32 +57,32 @@ def test_conv_fwt_haar_lvl2():
 
 def test_conv_fwt_haar_lvl2_odd():
     """Test an odd Haar wavelet convolution fwt."""
-    data = [
-        1.0,
-        2.0,
-        3.0,
-        4.0,
-        5.0,
-        6.0,
-        7.0,
-        8.0,
-        9.0,
-        10.0,
-        11.0,
-        12.0,
-        13.0,
-        14.0,
-        15.0,
-        16.0,
-        17.0,
-    ]
-    ptdata = torch.tensor(data).unsqueeze(0).unsqueeze(0)
-
+    data = np.array(
+        [
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+            5.0,
+            6.0,
+            7.0,
+            8.0,
+            9.0,
+            10.0,
+            11.0,
+            12.0,
+            13.0,
+            14.0,
+            15.0,
+            16.0,
+            17.0,
+        ]
+    )
     wavelet = pywt.Wavelet("haar")
 
     pycoeff = pywt.wavedec(data, wavelet, level=2, mode="reflect")
     pywt_coeffs = np.concatenate(pycoeff)
-    ptcoeff = wavedec(ptdata, wavelet, level=2, mode="reflect")
+    ptcoeff = wavedec(torch.from_numpy(data), wavelet, level=2, mode="reflect")
     ptwt_coeffs = torch.cat(ptcoeff, -1)[0, :].numpy()
     assert np.allclose(pywt_coeffs, ptwt_coeffs)
     rec = waverec(ptcoeff, wavelet)
@@ -95,7 +94,7 @@ def test_conv_fwt_haar_lvl4():
     generator = MackeyGenerator(batch_size=2, tmax=64, delta_t=1, device="cpu")
     mackey_data_1 = torch.squeeze(generator())
     wavelet = pywt.Wavelet("haar")
-    ptcoeff = wavedec(mackey_data_1.unsqueeze(1), wavelet, level=4)
+    ptcoeff = wavedec(mackey_data_1, wavelet, level=4)
     pycoeff = pywt.wavedec(mackey_data_1[0, :].numpy(), wavelet, level=4)
     ptwt_coeff = torch.cat(ptcoeff, -1)[0, :].numpy()
     pywt_coeff = np.concatenate(pycoeff)
@@ -103,7 +102,7 @@ def test_conv_fwt_haar_lvl4():
     print("haar coefficient error scale 4:", err, ["ok" if err < 1e-4 else "failed!"])
     assert np.allclose(pywt_coeff, ptwt_coeff, atol=1e-06)
 
-    reconstruction = waverec(wavedec(mackey_data_1.unsqueeze(1), wavelet), wavelet)
+    reconstruction = waverec(wavedec(mackey_data_1, wavelet), wavelet)
     err = torch.mean(torch.abs(mackey_data_1 - reconstruction)).numpy()
     print(
         "haar reconstruction error scale 4:", err, ["ok" if err < 1e-4 else "failed!"]
@@ -113,39 +112,39 @@ def test_conv_fwt_haar_lvl4():
 
 def test_conv_fwt_db2_lvl1():
     """Test a second level db2 conv-fwt."""
-    data = [
-        1.0,
-        2.0,
-        3.0,
-        4.0,
-        5.0,
-        6.0,
-        7.0,
-        8.0,
-        9.0,
-        10.0,
-        11.0,
-        12.0,
-        13.0,
-        14.0,
-        15.0,
-        16.0,
-    ]
-    npdata = np.array(data)
-    ptdata = torch.tensor(data).unsqueeze(0).unsqueeze(0)
+    data = np.array(
+        [
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+            5.0,
+            6.0,
+            7.0,
+            8.0,
+            9.0,
+            10.0,
+            11.0,
+            12.0,
+            13.0,
+            14.0,
+            15.0,
+            16.0,
+        ]
+    )
     # ------------------------- db2 wavelet tests ----------------------------
     wavelet = pywt.Wavelet("db2")
     coeffs = pywt.wavedec(data, wavelet, level=1, mode="reflect")
-    coeffs2 = wavedec(ptdata, wavelet, level=1, mode="reflect")
+    coeffs2 = wavedec(torch.from_numpy(data), wavelet, level=1, mode="reflect")
     ccoeffs = np.concatenate(coeffs, -1)
     ccoeffs2 = torch.cat(coeffs2, -1).numpy()
     err = np.mean(np.abs(ccoeffs - ccoeffs2))
     print("db2 coefficient error scale 1:", err, ["ok" if err < 1e-4 else "failed!"])
     assert np.allclose(ccoeffs, ccoeffs2, atol=1e-6)
     rec = waverec(coeffs2, wavelet)
-    err = np.mean(np.abs(npdata - rec.numpy()))
+    err = np.mean(np.abs(data - rec.numpy()))
     print("db2 reconstruction error scale 1:", err, ["ok" if err < 1e-4 else "failed!"])
-    assert np.allclose(npdata, rec.numpy())
+    assert np.allclose(data, rec.numpy())
 
 
 def test_conv_fwt_db5_lvl3():
@@ -155,7 +154,7 @@ def test_conv_fwt_db5_lvl3():
     mackey_data_1 = torch.squeeze(generator())
     wavelet = pywt.Wavelet("db5")
     for mode in ["reflect", "zero"]:
-        ptcoeff = wavedec(mackey_data_1.unsqueeze(1), wavelet, level=3, mode=mode)
+        ptcoeff = wavedec(mackey_data_1, wavelet, level=3, mode=mode)
         pycoeff = pywt.wavedec(mackey_data_1[0, :].numpy(), wavelet, level=3, mode=mode)
         cptcoeff = torch.cat(ptcoeff, -1)[0, :]
         cpycoeff = np.concatenate(pycoeff, -1)
@@ -169,9 +168,7 @@ def test_conv_fwt_db5_lvl3():
         )
         assert np.allclose(cpycoeff, cptcoeff.numpy(), atol=1e-6)
 
-        res = waverec(
-            wavedec(mackey_data_1.unsqueeze(1), wavelet, level=3, mode=mode), wavelet
-        )
+        res = waverec(wavedec(mackey_data_1, wavelet, level=3, mode=mode), wavelet)
         err = torch.mean(torch.abs(mackey_data_1 - res)).numpy()
         print(
             "db5 reconstruction error scale 3:",
@@ -181,9 +178,7 @@ def test_conv_fwt_db5_lvl3():
             mode,
         )
         assert np.allclose(mackey_data_1.numpy(), res.numpy())
-        res = waverec(
-            wavedec(mackey_data_1.unsqueeze(1), wavelet, level=4, mode=mode), wavelet
-        )
+        res = waverec(wavedec(mackey_data_1, wavelet, level=4, mode=mode), wavelet)
         err = torch.mean(torch.abs(mackey_data_1 - res)).numpy()
         print(
             "db5 reconstruction error scale 4:",
@@ -204,9 +199,7 @@ def test_conv_fwt():
         for wavelet_string in ["db1", "db2", "db3", "db4", "db5"]:
             for mode in ["reflect", "zero"]:
                 wavelet = pywt.Wavelet(wavelet_string)
-                ptcoeff = wavedec(
-                    mackey_data_1.unsqueeze(1), wavelet, level=level, mode=mode
-                )
+                ptcoeff = wavedec(mackey_data_1, wavelet, level=level, mode=mode)
                 pycoeff = pywt.wavedec(
                     mackey_data_1[0, :].numpy(), wavelet, level=level, mode=mode
                 )
@@ -223,7 +216,7 @@ def test_conv_fwt():
                 assert np.allclose(cptcoeff.numpy(), cpycoeff, atol=1e-6)
 
                 res = waverec(
-                    wavedec(mackey_data_1.unsqueeze(1), wavelet, level=3, mode=mode),
+                    wavedec(mackey_data_1, wavelet, level=3, mode=mode),
                     wavelet,
                 )
                 err = torch.mean(torch.abs(mackey_data_1 - res)).numpy()
@@ -237,7 +230,7 @@ def test_conv_fwt():
                 assert np.allclose(mackey_data_1.numpy(), res.numpy())
 
                 res = waverec(
-                    wavedec(mackey_data_1.unsqueeze(1), wavelet, level=4, mode=mode),
+                    wavedec(mackey_data_1, wavelet, level=4, mode=mode),
                     wavelet,
                 )
                 err = torch.mean(torch.abs(mackey_data_1 - res)).numpy()
@@ -264,11 +257,9 @@ def test_ripples_haar_lvl3():
                 [1 / 2.0, -1 / 2.0],
             )
 
-    data = [56.0, 40.0, 8.0, 24.0, 48.0, 48.0, 40.0, 16.0]
+    data = torch.tensor([56.0, 40.0, 8.0, 24.0, 48.0, 48.0, 40.0, 16.0])
     wavelet = pywt.Wavelet("unscaled Haar Wavelet", filter_bank=MyHaarFilterBank())
-    ptdata = torch.tensor(data).unsqueeze(0).unsqueeze(0)
-    coeffs = wavedec(ptdata, wavelet, level=3)
-    # print(coeffs)
+    coeffs = wavedec(data, wavelet, level=3)
     assert torch.squeeze(coeffs[0]).numpy() == 35.0
     assert torch.squeeze(coeffs[1]).numpy() == -3.0
     assert (torch.squeeze(coeffs[2]).numpy() == [16.0, 10.0]).all()
@@ -288,7 +279,7 @@ def test_orth_wavelet():
         torch.tensor(wavelet.dec_lo),
         torch.tensor(wavelet.dec_hi),
     )
-    res = waverec(wavedec(mackey_data_1.unsqueeze(1), orthwave), orthwave)
+    res = waverec(wavedec(mackey_data_1, orthwave), orthwave)
     err = torch.mean(torch.abs(mackey_data_1 - res.detach())).numpy()
     print(
         "orth reconstruction error scale 4:", err, ["ok" if err < 1e-4 else "failed!"]
@@ -302,12 +293,11 @@ def test_2d_haar_lvl1():
     face = np.transpose(
         scipy.misc.face()[128 : (512 + 128), 256 : (512 + 256)], [2, 0, 1]
     ).astype(np.float64)
-    pt_face = torch.tensor(face).unsqueeze(1)
     wavelet = pywt.Wavelet("haar")
 
     # single level haar - 2d
     coeff2d_pywt = pywt.dwt2(face, wavelet, mode="zero")
-    coeff2d = wavedec2(pt_face, wavelet, level=1, mode="constant")
+    coeff2d = wavedec2(torch.from_numpy(face), wavelet, level=1, mode="constant")
     flat_list_pywt = np.concatenate(flatten_2d_coeff_lst(coeff2d_pywt), -1)
     flat_list_ptwt = torch.cat(flatten_2d_coeff_lst(coeff2d), -1)
     cerr = np.mean(np.abs(flat_list_pywt - flat_list_ptwt.numpy()))
@@ -332,10 +322,9 @@ def test_2d_db2_lvl1():
     face = np.transpose(
         scipy.misc.face()[256 : (512 + 128), 256 : (512 + 128)], [2, 0, 1]
     ).astype(np.float64)
-    pt_face = torch.tensor(face).unsqueeze(1)
     wavelet = pywt.Wavelet("db2")
     coeff2d_pywt = pywt.dwt2(face, wavelet, mode="reflect")
-    coeff2d = wavedec2(pt_face, wavelet, level=1)
+    coeff2d = wavedec2(torch.from_numpy(face), wavelet, level=1)
     flat_list_pywt = np.concatenate(flatten_2d_coeff_lst(coeff2d_pywt), -1)
     flat_list_ptwt = torch.cat(flatten_2d_coeff_lst(coeff2d), -1)
     cerr = np.mean(np.abs(flat_list_pywt - flat_list_ptwt.numpy()))
@@ -355,10 +344,9 @@ def test_2d_haar_multi():
     face = np.transpose(
         scipy.misc.face()[256 : (512 + 128), 256 : (512 + 128)], [2, 0, 1]
     ).astype(np.float64)
-    pt_face = torch.tensor(face).unsqueeze(1)
     wavelet = pywt.Wavelet("haar")
     coeff2d_pywt = pywt.wavedec2(face, wavelet, mode="reflect", level=5)
-    coeff2d = wavedec2(pt_face, wavelet, level=5)
+    coeff2d = wavedec2(torch.from_numpy(face), wavelet, level=5)
     flat_list_pywt = np.concatenate(flatten_2d_coeff_lst(coeff2d_pywt), -1)
     flat_list_ptwt = torch.cat(flatten_2d_coeff_lst(coeff2d), -1)
     cerr = np.mean(np.abs(flat_list_pywt - flat_list_ptwt.numpy()))
@@ -394,9 +382,10 @@ def test_2d_wavedec_rec():
             face = np.transpose(
                 scipy.misc.face()[256 : (512 + 64), 256 : (512 + 64)], [2, 0, 1]
             ).astype(np.float64)
-            pt_face = torch.tensor(face).unsqueeze(1)
             wavelet = pywt.Wavelet(wavelet_str)
-            coeff2d = wavedec2(pt_face, wavelet, mode="reflect", level=level)
+            coeff2d = wavedec2(
+                torch.from_numpy(face), wavelet, mode="reflect", level=level
+            )
             pywt_coeff2d = pywt.wavedec2(face, wavelet, mode="reflect", level=level)
             for pos, coeffs in enumerate(pywt_coeff2d):
                 if type(coeffs) is tuple:

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -20,8 +20,7 @@ def _compare_trees1(
 ):
     data = np.random.rand(batch_size, length)
     wavelet = pywt.Wavelet(wavelet_str)
-    pt_data = torch.tensor(data)
-    twp = WaveletPacket(pt_data, wavelet, mode=ptwt_boundary)
+    twp = WaveletPacket(torch.from_numpy(data), wavelet, mode=ptwt_boundary)
     nodes = twp.get_level(max_lev)
     twp_lst = []
     for node in nodes:
@@ -157,7 +156,7 @@ def test_freq_order(level, wavelet_str, pywt_boundary):
 
 def test_packet_harbo_lvl3():
     """From Jensen, La Cour-Harbo, Rippels in Mathematics, Chapter 8 (page 89)."""
-    w = [56.0, 40.0, 8.0, 24.0, 48.0, 48.0, 40.0, 16.0]
+    data = np.array([56.0, 40.0, 8.0, 24.0, 48.0, 48.0, 40.0, 16.0])
 
     class MyHaarFilterBank(object):
         @property
@@ -170,14 +169,14 @@ def test_packet_harbo_lvl3():
             )
 
     wavelet = pywt.Wavelet("unscaled Haar Wavelet", filter_bank=MyHaarFilterBank())
-    data = torch.tensor(w).unsqueeze(0)
-    twp = WaveletPacket(data, wavelet, mode="reflect")
+
+    twp = WaveletPacket(torch.from_numpy(data), wavelet, mode="reflect")
     twp_nodes = twp.get_level(3)
     twp_lst = []
     for node in twp_nodes:
         twp_lst.append(torch.squeeze(twp[node]))
     torch_res = torch.stack(twp_lst).numpy()
-    wp = pywt.WaveletPacket(data=np.array(w), wavelet=wavelet, mode="reflect")
+    wp = pywt.WaveletPacket(data=data, wavelet=wavelet, mode="reflect")
     pywt_nodes = [node.path for node in wp.get_level(3, "freq")]
     np_lst = []
     for node in pywt_nodes:

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -10,7 +10,8 @@ from scipy import misc
 from src.ptwt.packets import WaveletPacket, WaveletPacket2D, get_freq_order
 
 
-def _compare_trees1(wavelet_str: str,
+def _compare_trees1(
+    wavelet_str: str,
     max_lev: int = 3,
     pywt_boundary: str = "zero",
     ptwt_boundary: str = "zero",
@@ -29,7 +30,9 @@ def _compare_trees1(wavelet_str: str,
 
     np_batches = []
     for batch_index in range(batch_size):
-        wp = pywt.WaveletPacket(data=data[batch_index], wavelet=wavelet, mode=pywt_boundary)
+        wp = pywt.WaveletPacket(
+            data=data[batch_index], wavelet=wavelet, mode=pywt_boundary
+        )
         nodes = [node.path for node in wp.get_level(max_lev, "freq")]
         np_lst = []
         for node in nodes:
@@ -47,7 +50,7 @@ def _compare_trees2(
     ptwt_boundary: str = "zero",
     height: int = 256,
     width: int = 256,
-    batch_size: int = 1
+    batch_size: int = 1,
 ):
 
     face = misc.face()[:height, :width]
@@ -71,7 +74,7 @@ def _compare_trees2(
     batch_np_packets = np.stack(batch_list, 0)
 
     # get the PyTorch decomposition
-    pt_data = torch.stack([torch.from_numpy(face)]*batch_size, 0)
+    pt_data = torch.stack([torch.from_numpy(face)] * batch_size, 0)
     ptwt_wp_tree = WaveletPacket2D(pt_data, wavelet=wavelet, mode=ptwt_boundary)
     packets = []
     for node in wp_keys:
@@ -90,8 +93,13 @@ def _compare_trees2(
 @pytest.mark.parametrize("batch_size", [2, 1])
 def test_2d_packets(max_lev, wavelet_str, boundary, batch_size):
     """Ensure pywt and ptwt produce equivalent wavelet 2d packet trees."""
-    _compare_trees2(wavelet_str, max_lev, pywt_boundary=boundary, ptwt_boundary=boundary,
-                    batch_size=batch_size)
+    _compare_trees2(
+        wavelet_str,
+        max_lev,
+        pywt_boundary=boundary,
+        ptwt_boundary=boundary,
+        batch_size=batch_size,
+    )
 
 
 @pytest.mark.slow
@@ -111,8 +119,13 @@ def test_boundary_matrix_packets2(max_lev, batch_size):
 @pytest.mark.parametrize("batch_size", [2, 1])
 def test_1d_packets(max_lev, wavelet_str, boundary, batch_size):
     """Ensure pywt and ptwt produce equivalent wavelet 1d packet trees."""
-    _compare_trees1(wavelet_str, max_lev, pywt_boundary=boundary, ptwt_boundary=boundary,
-                    batch_size=batch_size)
+    _compare_trees1(
+        wavelet_str,
+        max_lev,
+        pywt_boundary=boundary,
+        ptwt_boundary=boundary,
+        batch_size=batch_size,
+    )
 
 
 @pytest.mark.parametrize("level", [1, 2, 3, 4])
@@ -140,7 +153,6 @@ def test_freq_order(level, wavelet_str, pywt_boundary):
                 order_el.path == "".join(tree_el),
             )
             assert order_el.path == "".join(tree_el)
-
 
 
 def test_packet_harbo_lvl3():

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -10,99 +10,75 @@ from scipy import misc
 from src.ptwt.packets import WaveletPacket, WaveletPacket2D, get_freq_order
 
 
-def test_packet_harbo_lvl3():
-    """From Jensen, La Cour-Harbo, Rippels in Mathematics, Chapter 8 (page 89)."""
-    w = [56.0, 40.0, 8.0, 24.0, 48.0, 48.0, 40.0, 16.0]
-
-    class MyHaarFilterBank(object):
-        @property
-        def filter_bank(self):
-            return (
-                [1 / 2, 1 / 2.0],
-                [-1 / 2.0, 1 / 2.0],
-                [1 / 2.0, 1 / 2.0],
-                [1 / 2.0, -1 / 2.0],
-            )
-
-    wavelet = pywt.Wavelet("unscaled Haar Wavelet", filter_bank=MyHaarFilterBank())
-    data = torch.tensor(w).unsqueeze(0)
-    twp = WaveletPacket(data, wavelet, mode="reflect")
-    nodes = twp.get_level(3)
+def _compare_trees1(wavelet_str: str,
+    max_lev: int = 3,
+    pywt_boundary: str = "zero",
+    ptwt_boundary: str = "zero",
+    length: int = 256,
+    batch_size: int = 1,
+):
+    data = np.random.rand(batch_size, length)
+    wavelet = pywt.Wavelet(wavelet_str)
+    pt_data = torch.tensor(data)
+    twp = WaveletPacket(pt_data, wavelet, mode=ptwt_boundary)
+    nodes = twp.get_level(max_lev)
     twp_lst = []
     for node in nodes:
-        twp_lst.append(torch.squeeze(twp[node]))
-    res = torch.stack(twp_lst).numpy()
-    wp = pywt.WaveletPacket(data=np.array(w), wavelet=wavelet, mode="reflect")
-    nodes = [node.path for node in wp.get_level(3, "freq")]
-    np_lst = []
-    for node in nodes:
-        np_lst.append(wp[node].data)
-    viz = np.concatenate(np_lst)
+        twp_lst.append(twp[node])
+    torch_res = torch.cat(twp_lst, -1).numpy()
 
-    err = np.mean(np.abs(res - viz))
-    assert err < 1e-8
+    np_batches = []
+    for batch_index in range(batch_size):
+        wp = pywt.WaveletPacket(data=data[batch_index], wavelet=wavelet, mode=pywt_boundary)
+        nodes = [node.path for node in wp.get_level(max_lev, "freq")]
+        np_lst = []
+        for node in nodes:
+            np_lst.append(wp[node].data)
+        np_res = np.concatenate(np_lst, -1)
+        np_batches.append(np_res)
+    np_batches = np.stack(np_batches, 0)
+    assert np.allclose(torch_res, np_batches)
 
 
-def _compare_trees(
+def _compare_trees2(
     wavelet_str: str,
     max_lev: int,
     pywt_boundary: str = "zero",
     ptwt_boundary: str = "zero",
+    height: int = 256,
+    width: int = 256,
+    batch_size: int = 1
 ):
-    face = misc.face()[256:512, 256:512]
+
+    face = misc.face()[:height, :width]
+    face = np.mean(face, axis=-1).astype(np.float64)
     wavelet = pywt.Wavelet(wavelet_str)
-    wp_tree = pywt.WaveletPacket2D(
-        data=np.mean(face, axis=-1).astype(np.float64),
-        wavelet=wavelet,
-        mode=pywt_boundary,
-    )
-    # Get the full decomposition
-    wp_keys = list(product(["a", "v", "d", "h"], repeat=max_lev))
-    count = 0
-    img_rows = None
-    img = []
-    for node in wp_keys:
-        packet = np.squeeze(wp_tree["".join(node)].data)
-        if img_rows is not None:
-            img_rows = np.concatenate([img_rows, packet], axis=1)
-        else:
-            img_rows = packet
-        count += 1
-        if count >= np.sqrt(len(wp_keys)):
-            count = 0
-            img.append(img_rows)
-            img_rows = None
-    img_pywt = np.concatenate(img, axis=0)
-    pt_data = torch.unsqueeze(
-        torch.from_numpy(np.mean(face, axis=-1).astype(np.float64)), 0
-    )
-    ptwt_wp_tree = WaveletPacket2D(pt_data, wavelet=wavelet, mode=ptwt_boundary)
+    batch_list = []
+    for _ in range(batch_size):
+        wp_tree = pywt.WaveletPacket2D(
+            data=face,
+            wavelet=wavelet,
+            mode=pywt_boundary,
+        )
+        # Get the full decomposition
+        wp_keys = list(product(["a", "h", "v", "d"], repeat=max_lev))
+        np_packets = []
+        for node in wp_keys:
+            np_packet = wp_tree["".join(node)].data
+            np_packets.append(np_packet)
+        np_packets = np.stack(np_packets, 0)
+        batch_list.append(np_packets)
+    batch_np_packets = np.stack(batch_list, 0)
+
     # get the PyTorch decomposition
-    count = 0
-    img_pt = []
-    img_rows_pt = None
+    pt_data = torch.stack([torch.from_numpy(face)]*batch_size, 0)
+    ptwt_wp_tree = WaveletPacket2D(pt_data, wavelet=wavelet, mode=ptwt_boundary)
+    packets = []
     for node in wp_keys:
-        packet = torch.squeeze(ptwt_wp_tree["".join(node)])
-        if img_rows_pt is not None:
-            img_rows_pt = torch.cat([img_rows_pt, packet], axis=1)
-        else:
-            img_rows_pt = packet
-        count += 1
-        if count >= np.sqrt(len(wp_keys)):
-            count = 0
-            img_pt.append(img_rows_pt)
-            img_rows_pt = None
-    img_pt = torch.cat(img_pt, axis=0).numpy()
-    abs_err_img = np.abs(img_pt - img_pywt)
-    abs_err = np.mean(abs_err_img)
-    print(
-        wavelet_str,
-        max_lev,
-        "total error",
-        abs_err,
-        ["ok" if abs_err < 1e-4 else "failed!"],
-    )
-    assert np.allclose(img_pt, img_pywt)
+        packet = ptwt_wp_tree["".join(node)]
+        packets.append(packet)
+    packets_pt = torch.stack(packets, 1).numpy()
+    assert np.allclose(packets_pt, batch_np_packets)
 
 
 @pytest.mark.slow
@@ -111,16 +87,32 @@ def _compare_trees(
     "wavelet_str", ["haar", "db2", "db3", "db4", "db5", "db6", "db7", "db8"]
 )
 @pytest.mark.parametrize("boundary", ["zero", "reflect"])
-def test_2d_packets(max_lev, wavelet_str, boundary):
-    """Ensure pywt and ptwt produce equivalent wavelet packet trees."""
-    _compare_trees(wavelet_str, max_lev, pywt_boundary=boundary, ptwt_boundary=boundary)
+@pytest.mark.parametrize("batch_size", [2, 1])
+def test_2d_packets(max_lev, wavelet_str, boundary, batch_size):
+    """Ensure pywt and ptwt produce equivalent wavelet 2d packet trees."""
+    _compare_trees2(wavelet_str, max_lev, pywt_boundary=boundary, ptwt_boundary=boundary,
+                    batch_size=batch_size)
 
 
 @pytest.mark.slow
 @pytest.mark.parametrize("max_lev", [1, 2, 3, 4])
-def test_boundary_matrix_packets(max_lev):
-    """Ensure the sparse matrix haar tree and pywt-tree are the same."""
-    _compare_trees("db1", max_lev, "zero", "boundary")
+@pytest.mark.parametrize("batch_size", [1, 2])
+def test_boundary_matrix_packets2(max_lev, batch_size):
+    """Ensure the 2d - sparse matrix haar tree and pywt-tree are the same."""
+    _compare_trees2("db1", max_lev, "zero", "boundary", batch_size=batch_size)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("max_lev", [1, 2, 3, 4])
+@pytest.mark.parametrize(
+    "wavelet_str", ["haar", "db2", "db3", "db4", "db5", "db6", "db7", "db8"]
+)
+@pytest.mark.parametrize("boundary", ["zero", "reflect"])
+@pytest.mark.parametrize("batch_size", [2, 1])
+def test_1d_packets(max_lev, wavelet_str, boundary, batch_size):
+    """Ensure pywt and ptwt produce equivalent wavelet 1d packet trees."""
+    _compare_trees1(wavelet_str, max_lev, pywt_boundary=boundary, ptwt_boundary=boundary,
+                    batch_size=batch_size)
 
 
 @pytest.mark.parametrize("level", [1, 2, 3, 4])
@@ -148,3 +140,35 @@ def test_freq_order(level, wavelet_str, pywt_boundary):
                 order_el.path == "".join(tree_el),
             )
             assert order_el.path == "".join(tree_el)
+
+
+
+def test_packet_harbo_lvl3():
+    """From Jensen, La Cour-Harbo, Rippels in Mathematics, Chapter 8 (page 89)."""
+    w = [56.0, 40.0, 8.0, 24.0, 48.0, 48.0, 40.0, 16.0]
+
+    class MyHaarFilterBank(object):
+        @property
+        def filter_bank(self):
+            return (
+                [1 / 2, 1 / 2.0],
+                [-1 / 2.0, 1 / 2.0],
+                [1 / 2.0, 1 / 2.0],
+                [1 / 2.0, -1 / 2.0],
+            )
+
+    wavelet = pywt.Wavelet("unscaled Haar Wavelet", filter_bank=MyHaarFilterBank())
+    data = torch.tensor(w).unsqueeze(0)
+    twp = WaveletPacket(data, wavelet, mode="reflect")
+    twp_nodes = twp.get_level(3)
+    twp_lst = []
+    for node in twp_nodes:
+        twp_lst.append(torch.squeeze(twp[node]))
+    torch_res = torch.stack(twp_lst).numpy()
+    wp = pywt.WaveletPacket(data=np.array(w), wavelet=wavelet, mode="reflect")
+    pywt_nodes = [node.path for node in wp.get_level(3, "freq")]
+    np_lst = []
+    for node in pywt_nodes:
+        np_lst.append(wp[node].data)
+    np_res = np.concatenate(np_lst)
+    assert np.allclose(torch_res, np_res)


### PR DESCRIPTION
I promised not to commit to master anymore. So here is the pull request to fix the dimension problem from issue https://github.com/v0lta/PyTorch-Wavelet-Toolbox/issues/21 .
I have:
- Gone over our usage of `tf.squeeze` and
- Simplified and extended test coverage for batched packet transforms, including batch_size = 1. Which used to clash with our bare `tf.squeeze` statements.