### PR TITLE
Input shape handling

### DIFF
--- a/src/ptwt/conv_transform.py
+++ b/src/ptwt/conv_transform.py
@@ -207,6 +207,8 @@ def wavedec2(
     Args:
         data (torch.Tensor): The input data tensor of shape
             [batch_size, 1, height, width].
+            2d inputs are interpreted as [height, width],
+            3d inputs are interpreted as [batch_size, height, width].
         wavelet (Wavelet or str): A pywt wavelet compatible object or
                 the name of a pywt wavelet.
         level (int): The number of desired scales.
@@ -233,6 +235,11 @@ def wavedec2(
                                          level=2, mode="constant")
 
     """
+    if data.dim() == 2:
+        data = data.unsqueeze(0).unsqueeze(0)
+    elif data.dim() == 3:
+        data = data.unsqueeze(1)
+
     wavelet = _as_wavelet(wavelet)
     dec_lo, dec_hi, _, _ = get_filter_tensors(
         wavelet, flip=True, device=data.device, dtype=data.dtype

--- a/src/ptwt/conv_transform.py
+++ b/src/ptwt/conv_transform.py
@@ -210,7 +210,7 @@ def wavedec2(
             2d inputs are interpreted as [height, width],
             3d inputs are interpreted as [batch_size, height, width].
         wavelet (Wavelet or str): A pywt wavelet compatible object or
-                the name of a pywt wavelet.
+            the name of a pywt wavelet.
         level (int): The number of desired scales.
             Defaults to None.
         mode (str): The padding mode, i.e. zero or reflect.
@@ -380,10 +380,10 @@ def wavedec(
                          mode='zero', level=2)
 
     """
-    if len(data.shape) == 1:
+    if data.dim() == 1:
         # assume time series
         data = data.unsqueeze(0).unsqueeze(0)
-    elif len(data.shape) == 2:
+    elif data.dim() == 2:
         # assume batched time series
         data = data.unsqueeze(1)
 

--- a/src/ptwt/matmul_transform.py
+++ b/src/ptwt/matmul_transform.py
@@ -294,17 +294,24 @@ class MatrixWavedec(object):
 
         Args:
             input_signal (torch.Tensor): Batched input data [batch_size, time],
-                  should be of even length.
+                should be of even length. 1d inputs are interpreted as [time].
 
         Returns:
             List[torch.Tensor]: A list with the coefficients for each scale.
 
         Raises:
-            ValueError: If the decomposition level is not a positive integer.
+            ValueError: If the decomposition level is not a positive integer
+                or if the input signal has not the expected shape.
         """
         if input_signal.dim() == 1:
             # assume time series
             input_signal = input_signal.unsqueeze(0)
+        elif input_signal.dim() != 2:
+            raise ValueError(
+                f"Invalid input tensor shape {input_signal.size()}. "
+                "The input signal is expected to be of the form "
+                "[batch_size, length]."
+            )
 
         if input_signal.shape[-1] % 2 != 0:
             # odd length input

--- a/src/ptwt/matmul_transform.py
+++ b/src/ptwt/matmul_transform.py
@@ -302,7 +302,7 @@ class MatrixWavedec(object):
         Raises:
             ValueError: If the decomposition level is not a positive integer.
         """
-        if len(input_signal.shape) == 1:
+        if input_signal.dim() == 1:
             # assume time series
             input_signal = input_signal.unsqueeze(0)
 

--- a/src/ptwt/matmul_transform_2d.py
+++ b/src/ptwt/matmul_transform_2d.py
@@ -402,7 +402,7 @@ class MatrixWavedec2d(object):
             # we assume the shape [batch_size, color_channels, height, width]
             # and squeeze the single color channel
             input_signal = input_signal.squeeze(1)
-        else:
+        elif input_signal.dim() != 3:
             raise ValueError(
                 f"Invalid input tensor shape {input_signal.size()}. "
                 "The input signal is expected to be of the form "

--- a/src/ptwt/matmul_transform_2d.py
+++ b/src/ptwt/matmul_transform_2d.py
@@ -383,20 +383,31 @@ class MatrixWavedec2d(object):
 
         Args:
             input_signal (torch.Tensor): An input signal of shape
-                [batch_size, height, width]
+                [batch_size, height, width].
+                2d inputs are interpreted as [height, width].
+                Inputs of the form [batch_size, 1, height, width] are squeezed.
 
         Returns:
             (list): The resulting coefficients per level stored in
             a pywt style list.
 
         Raises:
-            ValueError: If the decomposition level is not a positive integer.
+            ValueError: If the decomposition level is not a positive integer
+                or if the input signal has not the expected shape.
         """
-        if input_signal.shape[1] == 1:
-            input_signal = input_signal.squeeze(1)
-
-        if len(input_signal.shape) == 2:
+        if input_signal.dim() == 2:
+            # add batch dim to unbatched input
             input_signal = input_signal.unsqueeze(0)
+        elif input_signal.dim() == 4 and input_signal.size(1) == 1:
+            # we assume the shape [batch_size, color_channels, height, width]
+            # and squeeze the single color channel
+            input_signal = input_signal.squeeze(1)
+        else:
+            raise ValueError(
+                f"Invalid input tensor shape {input_signal.size()}. "
+                "The input signal is expected to be of the form "
+                "[batch_size, height, width]."
+            )
 
         batch_size, height, width = input_signal.shape
 

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -114,23 +114,15 @@ class WaveletPacket(BaseDict):
             ]
         return graycode_order
 
-    # ignoring missing return type, as recursive nesting is currently not supported
-    # see https://github.com/python/mypy/issues/731
-    def _recursive_dwt(  # type: ignore[no-untyped-def]
-        self, data: torch.Tensor, level: int, path: str
-    ):
+    def _recursive_dwt(self, data: torch.Tensor, level: int, path: str) -> None:
         if not self.max_level:
             raise AssertionError
 
         self.data[path] = data
         if level < self.max_level:
             res_lo, res_hi = self._get_wavedec(data.shape[-1])(data)
-            return (
-                self._recursive_dwt(res_lo, level + 1, path + "a"),
-                self._recursive_dwt(res_hi, level + 1, path + "d"),
-            )
-        else:
-            self.data[path] = data
+            self._recursive_dwt(res_lo, level + 1, path + "a")
+            self._recursive_dwt(res_hi, level + 1, path + "d")
 
 
 class WaveletPacket2D(BaseDict):

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -215,28 +215,20 @@ class WaveletPacket2D(BaseDict):
         else:
             return partial(wavedec2, wavelet=self.wavelet, level=1, mode=self.mode)
 
-    # ignoring missing return type, as recursive nesting is currently not supported
-    # see https://github.com/python/mypy/issues/731
-    def _recursive_dwt2d(  # type: ignore[no-untyped-def]
-        self, data: torch.Tensor, level: int, path: str
-    ):
+    def _recursive_dwt2d(self, data: torch.Tensor, level: int, path: str) -> None:
         if not self.max_level:
             raise AssertionError
-        self.data[path] = torch.squeeze(data, 1)
+        self.data[path] = data
         if level < self.max_level:
             result_a, (result_h, result_v, result_d) = self._get_wavedec(
                 data.shape[-2:]
             )(data)
             # assert for type checking
             assert not isinstance(result_a, tuple)
-            return (
-                self._recursive_dwt2d(result_a, level + 1, path + "a"),
-                self._recursive_dwt2d(result_h, level + 1, path + "h"),
-                self._recursive_dwt2d(result_v, level + 1, path + "v"),
-                self._recursive_dwt2d(result_d, level + 1, path + "d"),
-            )
-        else:
-            self.data[path] = torch.squeeze(data, 1)
+            self._recursive_dwt2d(result_a, level + 1, path + "a")
+            self._recursive_dwt2d(result_h, level + 1, path + "h")
+            self._recursive_dwt2d(result_v, level + 1, path + "v")
+            self._recursive_dwt2d(result_d, level + 1, path + "d")
 
 
 def get_freq_order(level: int) -> List[List[Tuple[str, ...]]]:

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -189,9 +189,6 @@ class WaveletPacket2D(BaseDict):
             max_level = pywt.dwt_max_level(min(data.shape[-2:]), self.wavelet.dec_len)
         self.max_level = max_level
 
-        if data.dim() == 3:
-            data = torch.unsqueeze(data, 1)
-
         self._recursive_dwt2d(data, level=0, path="")
         return self
 

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -118,6 +118,11 @@ class WaveletPacket(BaseDict):
         if not self.max_level:
             raise AssertionError
 
+        # TODO: This is a workaround since the convolutional transforms insert a
+        #       squeezable dimension. We should adapt the wavedec code instead.
+        if data.dim() == 3:
+            data = data.squeeze(1)
+
         self.data[path] = data
         if level < self.max_level:
             res_lo, res_hi = self._get_wavedec(data.shape[-1])(data)
@@ -215,6 +220,12 @@ class WaveletPacket2D(BaseDict):
     def _recursive_dwt2d(self, data: torch.Tensor, level: int, path: str) -> None:
         if not self.max_level:
             raise AssertionError
+
+        # TODO: This is a workaround since the convolutional transforms insert a
+        #       squeezable dimension. We should adapt the wavedec2 code instead.
+        if data.dim() == 4:
+            data = data.squeeze(1)
+
         self.data[path] = data
         if level < self.max_level:
             result_a, (result_h, result_v, result_d) = self._get_wavedec(

--- a/tests/test_boundary_filters.py
+++ b/tests/test_boundary_filters.py
@@ -132,10 +132,9 @@ def test_matrix_analysis_fwt_2d_haar(size, level):
     face = np.mean(
         scipy.misc.face()[256 : (256 + size[0]), 256 : (256 + size[1])], -1
     ).astype(np.float64)
-    pt_face = torch.tensor(face)
     wavelet = pywt.Wavelet("haar")
     matrixfwt = MatrixWavedec2d(wavelet, level=level)
-    mat_coeff = matrixfwt(pt_face.unsqueeze(0))
+    mat_coeff = matrixfwt(torch.from_numpy(face))
     conv_coeff = pywt.wavedec2(face, wavelet, level=level, mode="zero")
     flat_mat_coeff = torch.cat(flatten_2d_coeff_lst(mat_coeff), -1)
     flat_conv_coeff = np.concatenate(flatten_2d_coeff_lst(conv_coeff), -1)
@@ -169,10 +168,9 @@ def test_boundary_matrix_fwt_2d(wavelet_str, size, level, separable):
     face = np.mean(
         scipy.misc.face()[256 : (256 + size[0]), 256 : (256 + size[1])], -1
     ).astype(np.float64)
-    pt_face = torch.tensor(face)
     wavelet = pywt.Wavelet(wavelet_str)
     matrixfwt = MatrixWavedec2d(wavelet, level=level, separable=separable)
-    mat_coeff = matrixfwt(pt_face.unsqueeze(0))
+    mat_coeff = matrixfwt(torch.from_numpy(face))
     matrixifwt = MatrixWaverec2d(wavelet, separable=separable)
     reconstruction = matrixifwt(mat_coeff).squeeze(0)
     # remove the padding
@@ -206,7 +204,7 @@ def test_batched_2d_matrix_fwt_ifwt(wavelet_str, level, size, separable):
     face = scipy.misc.face()[256 : (256 + size[0]), 256 : (256 + size[1])].astype(
         np.float64
     )
-    pt_face = torch.tensor(face).permute([2, 0, 1])
+    pt_face = torch.from_numpy(face).permute([2, 0, 1])
     wavelet = pywt.Wavelet(wavelet_str)
     matrixfwt = MatrixWavedec2d(wavelet, level=level, separable=separable)
     mat_coeff = matrixfwt(pt_face)
@@ -284,8 +282,7 @@ def test_matrix_transform_2d_rebuild(wavelet_str, separable):
             face = np.mean(
                 scipy.misc.face()[256 : (256 + size[0]), 256 : (256 + size[1])], -1
             ).astype(np.float64)
-            pt_face = torch.tensor(face)
-            mat_coeff = matrixfwt(pt_face.unsqueeze(0))
+            mat_coeff = matrixfwt(torch.from_numpy(face))
             reconstruction = matrixifwt(mat_coeff).squeeze(0)
             # remove the padding
             if size[0] % 2 != 0:

--- a/tests/test_convolution_fwt.py
+++ b/tests/test_convolution_fwt.py
@@ -19,30 +19,29 @@ from src.ptwt.wavelets_learnable import SoftOrthogonalWavelet
 
 def test_conv_fwt_haar_lvl2():
     """Test Haar wavelet level two conv fwt."""
-    data = [
-        1.0,
-        2.0,
-        3.0,
-        4.0,
-        5.0,
-        6.0,
-        7.0,
-        8.0,
-        9.0,
-        10.0,
-        11.0,
-        12.0,
-        13.0,
-        14.0,
-        15.0,
-        16.0,
-    ]
-    # npdata = np.array(data)
-    ptdata = torch.tensor(data).unsqueeze(0).unsqueeze(0)
-
+    data = np.array(
+        [
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+            5.0,
+            6.0,
+            7.0,
+            8.0,
+            9.0,
+            10.0,
+            11.0,
+            12.0,
+            13.0,
+            14.0,
+            15.0,
+            16.0,
+        ]
+    )
     wavelet = pywt.Wavelet("haar")
     coeffs = pywt.wavedec(data, wavelet, level=2)
-    coeffs2 = wavedec(ptdata, wavelet, level=2)
+    coeffs2 = wavedec(torch.from_numpy(data), wavelet, level=2)
     assert len(coeffs) == len(coeffs2)
 
     pywt_coeffs = np.concatenate(coeffs)
@@ -58,32 +57,32 @@ def test_conv_fwt_haar_lvl2():
 
 def test_conv_fwt_haar_lvl2_odd():
     """Test an odd Haar wavelet convolution fwt."""
-    data = [
-        1.0,
-        2.0,
-        3.0,
-        4.0,
-        5.0,
-        6.0,
-        7.0,
-        8.0,
-        9.0,
-        10.0,
-        11.0,
-        12.0,
-        13.0,
-        14.0,
-        15.0,
-        16.0,
-        17.0,
-    ]
-    ptdata = torch.tensor(data).unsqueeze(0).unsqueeze(0)
-
+    data = np.array(
+        [
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+            5.0,
+            6.0,
+            7.0,
+            8.0,
+            9.0,
+            10.0,
+            11.0,
+            12.0,
+            13.0,
+            14.0,
+            15.0,
+            16.0,
+            17.0,
+        ]
+    )
     wavelet = pywt.Wavelet("haar")
 
     pycoeff = pywt.wavedec(data, wavelet, level=2, mode="reflect")
     pywt_coeffs = np.concatenate(pycoeff)
-    ptcoeff = wavedec(ptdata, wavelet, level=2, mode="reflect")
+    ptcoeff = wavedec(torch.from_numpy(data), wavelet, level=2, mode="reflect")
     ptwt_coeffs = torch.cat(ptcoeff, -1)[0, :].numpy()
     assert np.allclose(pywt_coeffs, ptwt_coeffs)
     rec = waverec(ptcoeff, wavelet)
@@ -95,7 +94,7 @@ def test_conv_fwt_haar_lvl4():
     generator = MackeyGenerator(batch_size=2, tmax=64, delta_t=1, device="cpu")
     mackey_data_1 = torch.squeeze(generator())
     wavelet = pywt.Wavelet("haar")
-    ptcoeff = wavedec(mackey_data_1.unsqueeze(1), wavelet, level=4)
+    ptcoeff = wavedec(mackey_data_1, wavelet, level=4)
     pycoeff = pywt.wavedec(mackey_data_1[0, :].numpy(), wavelet, level=4)
     ptwt_coeff = torch.cat(ptcoeff, -1)[0, :].numpy()
     pywt_coeff = np.concatenate(pycoeff)
@@ -103,7 +102,7 @@ def test_conv_fwt_haar_lvl4():
     print("haar coefficient error scale 4:", err, ["ok" if err < 1e-4 else "failed!"])
     assert np.allclose(pywt_coeff, ptwt_coeff, atol=1e-06)
 
-    reconstruction = waverec(wavedec(mackey_data_1.unsqueeze(1), wavelet), wavelet)
+    reconstruction = waverec(wavedec(mackey_data_1, wavelet), wavelet)
     err = torch.mean(torch.abs(mackey_data_1 - reconstruction)).numpy()
     print(
         "haar reconstruction error scale 4:", err, ["ok" if err < 1e-4 else "failed!"]
@@ -113,39 +112,39 @@ def test_conv_fwt_haar_lvl4():
 
 def test_conv_fwt_db2_lvl1():
     """Test a second level db2 conv-fwt."""
-    data = [
-        1.0,
-        2.0,
-        3.0,
-        4.0,
-        5.0,
-        6.0,
-        7.0,
-        8.0,
-        9.0,
-        10.0,
-        11.0,
-        12.0,
-        13.0,
-        14.0,
-        15.0,
-        16.0,
-    ]
-    npdata = np.array(data)
-    ptdata = torch.tensor(data).unsqueeze(0).unsqueeze(0)
+    data = np.array(
+        [
+            1.0,
+            2.0,
+            3.0,
+            4.0,
+            5.0,
+            6.0,
+            7.0,
+            8.0,
+            9.0,
+            10.0,
+            11.0,
+            12.0,
+            13.0,
+            14.0,
+            15.0,
+            16.0,
+        ]
+    )
     # ------------------------- db2 wavelet tests ----------------------------
     wavelet = pywt.Wavelet("db2")
     coeffs = pywt.wavedec(data, wavelet, level=1, mode="reflect")
-    coeffs2 = wavedec(ptdata, wavelet, level=1, mode="reflect")
+    coeffs2 = wavedec(torch.from_numpy(data), wavelet, level=1, mode="reflect")
     ccoeffs = np.concatenate(coeffs, -1)
     ccoeffs2 = torch.cat(coeffs2, -1).numpy()
     err = np.mean(np.abs(ccoeffs - ccoeffs2))
     print("db2 coefficient error scale 1:", err, ["ok" if err < 1e-4 else "failed!"])
     assert np.allclose(ccoeffs, ccoeffs2, atol=1e-6)
     rec = waverec(coeffs2, wavelet)
-    err = np.mean(np.abs(npdata - rec.numpy()))
+    err = np.mean(np.abs(data - rec.numpy()))
     print("db2 reconstruction error scale 1:", err, ["ok" if err < 1e-4 else "failed!"])
-    assert np.allclose(npdata, rec.numpy())
+    assert np.allclose(data, rec.numpy())
 
 
 def test_conv_fwt_db5_lvl3():
@@ -155,7 +154,7 @@ def test_conv_fwt_db5_lvl3():
     mackey_data_1 = torch.squeeze(generator())
     wavelet = pywt.Wavelet("db5")
     for mode in ["reflect", "zero"]:
-        ptcoeff = wavedec(mackey_data_1.unsqueeze(1), wavelet, level=3, mode=mode)
+        ptcoeff = wavedec(mackey_data_1, wavelet, level=3, mode=mode)
         pycoeff = pywt.wavedec(mackey_data_1[0, :].numpy(), wavelet, level=3, mode=mode)
         cptcoeff = torch.cat(ptcoeff, -1)[0, :]
         cpycoeff = np.concatenate(pycoeff, -1)
@@ -169,9 +168,7 @@ def test_conv_fwt_db5_lvl3():
         )
         assert np.allclose(cpycoeff, cptcoeff.numpy(), atol=1e-6)
 
-        res = waverec(
-            wavedec(mackey_data_1.unsqueeze(1), wavelet, level=3, mode=mode), wavelet
-        )
+        res = waverec(wavedec(mackey_data_1, wavelet, level=3, mode=mode), wavelet)
         err = torch.mean(torch.abs(mackey_data_1 - res)).numpy()
         print(
             "db5 reconstruction error scale 3:",
@@ -181,9 +178,7 @@ def test_conv_fwt_db5_lvl3():
             mode,
         )
         assert np.allclose(mackey_data_1.numpy(), res.numpy())
-        res = waverec(
-            wavedec(mackey_data_1.unsqueeze(1), wavelet, level=4, mode=mode), wavelet
-        )
+        res = waverec(wavedec(mackey_data_1, wavelet, level=4, mode=mode), wavelet)
         err = torch.mean(torch.abs(mackey_data_1 - res)).numpy()
         print(
             "db5 reconstruction error scale 4:",
@@ -204,9 +199,7 @@ def test_conv_fwt():
         for wavelet_string in ["db1", "db2", "db3", "db4", "db5"]:
             for mode in ["reflect", "zero"]:
                 wavelet = pywt.Wavelet(wavelet_string)
-                ptcoeff = wavedec(
-                    mackey_data_1.unsqueeze(1), wavelet, level=level, mode=mode
-                )
+                ptcoeff = wavedec(mackey_data_1, wavelet, level=level, mode=mode)
                 pycoeff = pywt.wavedec(
                     mackey_data_1[0, :].numpy(), wavelet, level=level, mode=mode
                 )
@@ -223,7 +216,7 @@ def test_conv_fwt():
                 assert np.allclose(cptcoeff.numpy(), cpycoeff, atol=1e-6)
 
                 res = waverec(
-                    wavedec(mackey_data_1.unsqueeze(1), wavelet, level=3, mode=mode),
+                    wavedec(mackey_data_1, wavelet, level=3, mode=mode),
                     wavelet,
                 )
                 err = torch.mean(torch.abs(mackey_data_1 - res)).numpy()
@@ -237,7 +230,7 @@ def test_conv_fwt():
                 assert np.allclose(mackey_data_1.numpy(), res.numpy())
 
                 res = waverec(
-                    wavedec(mackey_data_1.unsqueeze(1), wavelet, level=4, mode=mode),
+                    wavedec(mackey_data_1, wavelet, level=4, mode=mode),
                     wavelet,
                 )
                 err = torch.mean(torch.abs(mackey_data_1 - res)).numpy()
@@ -264,11 +257,9 @@ def test_ripples_haar_lvl3():
                 [1 / 2.0, -1 / 2.0],
             )
 
-    data = [56.0, 40.0, 8.0, 24.0, 48.0, 48.0, 40.0, 16.0]
+    data = torch.tensor([56.0, 40.0, 8.0, 24.0, 48.0, 48.0, 40.0, 16.0])
     wavelet = pywt.Wavelet("unscaled Haar Wavelet", filter_bank=MyHaarFilterBank())
-    ptdata = torch.tensor(data).unsqueeze(0).unsqueeze(0)
-    coeffs = wavedec(ptdata, wavelet, level=3)
-    # print(coeffs)
+    coeffs = wavedec(data, wavelet, level=3)
     assert torch.squeeze(coeffs[0]).numpy() == 35.0
     assert torch.squeeze(coeffs[1]).numpy() == -3.0
     assert (torch.squeeze(coeffs[2]).numpy() == [16.0, 10.0]).all()
@@ -288,7 +279,7 @@ def test_orth_wavelet():
         torch.tensor(wavelet.dec_lo),
         torch.tensor(wavelet.dec_hi),
     )
-    res = waverec(wavedec(mackey_data_1.unsqueeze(1), orthwave), orthwave)
+    res = waverec(wavedec(mackey_data_1, orthwave), orthwave)
     err = torch.mean(torch.abs(mackey_data_1 - res.detach())).numpy()
     print(
         "orth reconstruction error scale 4:", err, ["ok" if err < 1e-4 else "failed!"]
@@ -302,12 +293,11 @@ def test_2d_haar_lvl1():
     face = np.transpose(
         scipy.misc.face()[128 : (512 + 128), 256 : (512 + 256)], [2, 0, 1]
     ).astype(np.float64)
-    pt_face = torch.tensor(face).unsqueeze(1)
     wavelet = pywt.Wavelet("haar")
 
     # single level haar - 2d
     coeff2d_pywt = pywt.dwt2(face, wavelet, mode="zero")
-    coeff2d = wavedec2(pt_face, wavelet, level=1, mode="constant")
+    coeff2d = wavedec2(torch.from_numpy(face), wavelet, level=1, mode="constant")
     flat_list_pywt = np.concatenate(flatten_2d_coeff_lst(coeff2d_pywt), -1)
     flat_list_ptwt = torch.cat(flatten_2d_coeff_lst(coeff2d), -1)
     cerr = np.mean(np.abs(flat_list_pywt - flat_list_ptwt.numpy()))
@@ -332,10 +322,9 @@ def test_2d_db2_lvl1():
     face = np.transpose(
         scipy.misc.face()[256 : (512 + 128), 256 : (512 + 128)], [2, 0, 1]
     ).astype(np.float64)
-    pt_face = torch.tensor(face).unsqueeze(1)
     wavelet = pywt.Wavelet("db2")
     coeff2d_pywt = pywt.dwt2(face, wavelet, mode="reflect")
-    coeff2d = wavedec2(pt_face, wavelet, level=1)
+    coeff2d = wavedec2(torch.from_numpy(face), wavelet, level=1)
     flat_list_pywt = np.concatenate(flatten_2d_coeff_lst(coeff2d_pywt), -1)
     flat_list_ptwt = torch.cat(flatten_2d_coeff_lst(coeff2d), -1)
     cerr = np.mean(np.abs(flat_list_pywt - flat_list_ptwt.numpy()))
@@ -355,10 +344,9 @@ def test_2d_haar_multi():
     face = np.transpose(
         scipy.misc.face()[256 : (512 + 128), 256 : (512 + 128)], [2, 0, 1]
     ).astype(np.float64)
-    pt_face = torch.tensor(face).unsqueeze(1)
     wavelet = pywt.Wavelet("haar")
     coeff2d_pywt = pywt.wavedec2(face, wavelet, mode="reflect", level=5)
-    coeff2d = wavedec2(pt_face, wavelet, level=5)
+    coeff2d = wavedec2(torch.from_numpy(face), wavelet, level=5)
     flat_list_pywt = np.concatenate(flatten_2d_coeff_lst(coeff2d_pywt), -1)
     flat_list_ptwt = torch.cat(flatten_2d_coeff_lst(coeff2d), -1)
     cerr = np.mean(np.abs(flat_list_pywt - flat_list_ptwt.numpy()))
@@ -394,9 +382,10 @@ def test_2d_wavedec_rec():
             face = np.transpose(
                 scipy.misc.face()[256 : (512 + 64), 256 : (512 + 64)], [2, 0, 1]
             ).astype(np.float64)
-            pt_face = torch.tensor(face).unsqueeze(1)
             wavelet = pywt.Wavelet(wavelet_str)
-            coeff2d = wavedec2(pt_face, wavelet, mode="reflect", level=level)
+            coeff2d = wavedec2(
+                torch.from_numpy(face), wavelet, mode="reflect", level=level
+            )
             pywt_coeff2d = pywt.wavedec2(face, wavelet, mode="reflect", level=level)
             for pos, coeffs in enumerate(pywt_coeff2d):
                 if type(coeffs) is tuple:

--- a/tests/test_matrix_fwt.py
+++ b/tests/test_matrix_fwt.py
@@ -1,7 +1,5 @@
 """Test the fwt and ifwt matrices."""
 # Written by moritz ( @ wolter.tech ) in 2021
-import time
-
 import numpy as np
 import pytest
 import pywt

--- a/tests/test_matrix_fwt.py
+++ b/tests/test_matrix_fwt.py
@@ -51,9 +51,8 @@ def test_fwt_ifwt_level_1():
     # level 1
     coeffs = pywt.dwt(data2, wavelet)
     print(coeffs[0], coeffs[1])
-    pt_data = torch.from_numpy(data2).unsqueeze(0)
     matrix_wavedec = MatrixWavedec(wavelet, 1)
-    coeffsmat1 = matrix_wavedec(pt_data)
+    coeffsmat1 = matrix_wavedec(torch.from_numpy(data2))
     err1 = np.mean(np.abs(coeffs[0] - coeffsmat1[0].squeeze().numpy()))
     err2 = np.mean(np.abs(coeffs[1] - coeffsmat1[1].squeeze().numpy()))
     print(err1 < 0.00001, err2 < 0.00001)
@@ -86,11 +85,9 @@ def test_fwt_ifwt_level_2():
             18.0,
         ]
     )
-    pt_data = torch.from_numpy(data2).unsqueeze(0)
-
     coeffs2 = pywt.wavedec(data2, wavelet, level=2, mode="zero")
     matrix_wavedec = MatrixWavedec(wavelet, 2)
-    coeffsmat2 = matrix_wavedec(pt_data)
+    coeffsmat2 = matrix_wavedec(torch.from_numpy(data2))
 
     err1 = np.mean(np.abs(coeffs2[0] - coeffsmat2[0].squeeze().numpy()))
     err2 = np.mean(np.abs(coeffs2[1] - coeffsmat2[1].squeeze().numpy()))
@@ -128,10 +125,9 @@ def test_fwt_ifwt_level_3():
             16.0,
         ]
     )
-    pt_data = torch.from_numpy(data2).unsqueeze(0)
     coeffs3 = pywt.wavedec(data2, wavelet, level=3)
     matrix_wavedec = MatrixWavedec(wavelet, level=3)
-    coeffsmat3 = matrix_wavedec(pt_data)
+    coeffsmat3 = matrix_wavedec(torch.from_numpy(data2))
 
     err1 = np.mean(np.abs(coeffs3[0] - coeffsmat3[0].squeeze().numpy()))
     err2 = np.mean(np.abs(coeffs3[1] - coeffsmat3[1].squeeze().numpy()))
@@ -146,9 +142,9 @@ def test_fwt_ifwt_level_3():
 
     matrix_waverec = MatrixWaverec(wavelet)
     reconstructed_data = matrix_waverec(coeffsmat3)
-    err5 = torch.mean(torch.abs(pt_data - reconstructed_data))
+    err5 = torch.mean(torch.abs(torch.from_numpy(data2) - reconstructed_data))
     print("abs ifwt 3 reconstruction error", err5)
-    assert np.allclose(pt_data.numpy(), reconstructed_data.numpy())
+    assert np.allclose(data2, reconstructed_data.numpy())
 
 
 @pytest.mark.slow
@@ -158,15 +154,12 @@ def test_fwt_ifwt_mackey_haar():
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     generator = MackeyGenerator(batch_size=2, tmax=512, delta_t=1, device=device)
     wavelet = pywt.Wavelet("haar")
-    pt_data = torch.squeeze(generator()).cpu()
-    numpy_data = pt_data.cpu().numpy()
-    pywt_start = time.time()
-    coeffs_max = pywt.wavedec(numpy_data, wavelet, level=9)
-    time_pywt = time.time() - pywt_start
-    sparse_fwt_start = time.time()
+    pt_data = torch.squeeze(generator())
+
+    coeffs_max = pywt.wavedec(pt_data.cpu().numpy(), wavelet, level=9)
+
     matrix_wavedec = MatrixWavedec(wavelet, 9)
     coeffs_mat_max = matrix_wavedec(pt_data)
-    time_sparse_fwt = time.time() - sparse_fwt_start
 
     test_lst = []
     for test_no in range(9):
@@ -175,8 +168,6 @@ def test_fwt_ifwt_mackey_haar():
             < 0.001
         )
     print(test_lst)
-    print("time pywt", time_pywt)
-    print("time_sparse_wt", time_sparse_fwt)
 
     # test the inverse fwt.
     matrix_waverec = MatrixWaverec(wavelet)

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -20,8 +20,7 @@ def _compare_trees1(
 ):
     data = np.random.rand(batch_size, length)
     wavelet = pywt.Wavelet(wavelet_str)
-    pt_data = torch.tensor(data)
-    twp = WaveletPacket(pt_data, wavelet, mode=ptwt_boundary)
+    twp = WaveletPacket(torch.from_numpy(data), wavelet, mode=ptwt_boundary)
     nodes = twp.get_level(max_lev)
     twp_lst = []
     for node in nodes:
@@ -157,7 +156,7 @@ def test_freq_order(level, wavelet_str, pywt_boundary):
 
 def test_packet_harbo_lvl3():
     """From Jensen, La Cour-Harbo, Rippels in Mathematics, Chapter 8 (page 89)."""
-    w = [56.0, 40.0, 8.0, 24.0, 48.0, 48.0, 40.0, 16.0]
+    data = np.array([56.0, 40.0, 8.0, 24.0, 48.0, 48.0, 40.0, 16.0])
 
     class MyHaarFilterBank(object):
         @property
@@ -170,14 +169,14 @@ def test_packet_harbo_lvl3():
             )
 
     wavelet = pywt.Wavelet("unscaled Haar Wavelet", filter_bank=MyHaarFilterBank())
-    data = torch.tensor(w).unsqueeze(0)
-    twp = WaveletPacket(data, wavelet, mode="reflect")
+
+    twp = WaveletPacket(torch.from_numpy(data), wavelet, mode="reflect")
     twp_nodes = twp.get_level(3)
     twp_lst = []
     for node in twp_nodes:
         twp_lst.append(torch.squeeze(twp[node]))
     torch_res = torch.stack(twp_lst).numpy()
-    wp = pywt.WaveletPacket(data=np.array(w), wavelet=wavelet, mode="reflect")
+    wp = pywt.WaveletPacket(data=data, wavelet=wavelet, mode="reflect")
     pywt_nodes = [node.path for node in wp.get_level(3, "freq")]
     np_lst = []
     for node in pywt_nodes:


### PR DESCRIPTION
This makes the input shape handling in the different wavelet decomposition methods more lenient, e.g.
* missing batch dimensions are unsqueezed
* in the convolutional case, a missing "color channel" is unsqueezed

Consequently, this removes the explicit unsqueeze/squeeze calls etc. before the call of a wavelet decomposition from the unit tests and packets.

While I was at it, I also cleaned up the unit tests a bit and refactored some code.

**Note:** Currently the convolutional transformations differ from the matrix based transformations as they require and return an extra (squeezable) dimension. I don't think this inconsistency is good and we should probably patch the convolutional transforms. Until then, the wavelet packet code checks for this extra dimension and squeezes it to be consistent with `pywt` and the matrix transformations.
