### PR TITLE
Add coverage report and docstring coverage to tox

### DIFF
--- a/src/ptwt/__init__.py
+++ b/src/ptwt/__init__.py
@@ -1,3 +1,4 @@
+"""Differentiable and gpu enabled fast wavelet transforms in PyTorch."""
 from .conv_transform import wavedec, wavedec2, waverec, waverec2
 from .matmul_transform import MatrixWavedec, MatrixWaverec
 from .matmul_transform_2d import MatrixWavedec2d, MatrixWaverec2d

--- a/src/ptwt/_mackey_glass.py
+++ b/src/ptwt/_mackey_glass.py
@@ -36,7 +36,7 @@ def generate_mackey(
     steps = int(tmax / delta_t) + 200
 
     # multi-dimensional data.
-    def mackey(
+    def _mackey(
         x: torch.Tensor, tau: int, gamma: float = 0.1, beta: float = 0.2, n: int = 10
     ) -> torch.Tensor:
         return beta * x[:, -tau] / (1 + torch.pow(x[:, -tau], n)) - gamma * x[:, -1]
@@ -53,7 +53,7 @@ def generate_mackey(
     x = x0
     # forward_euler
     for _ in range(steps):
-        res = torch.unsqueeze(x[:, -1] + delta_t * mackey(x, tau), -1)
+        res = torch.unsqueeze(x[:, -1] + delta_t * _mackey(x, tau), -1)
         x = torch.cat([x, res], -1)
     discard = 200 + tau
     return x[:, discard:]

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -271,7 +271,7 @@ def get_freq_order(level: int) -> List[List[Tuple[str, ...]]]:
             ]
         return graycode_order
 
-    def expand_2d_path(path: Tuple[str, ...]) -> Tuple[str, str]:
+    def _expand_2d_path(path: Tuple[str, ...]) -> Tuple[str, str]:
         expanded_paths = {"d": "hh", "h": "hl", "v": "lh", "a": "ll"}
         return (
             "".join([expanded_paths[p][0] for p in path]),
@@ -280,7 +280,7 @@ def get_freq_order(level: int) -> List[List[Tuple[str, ...]]]:
 
     nodes_dict: Dict[str, Dict[str, Tuple[str, ...]]] = {}
     for (row_path, col_path), node in [
-        (expand_2d_path(node), node) for node in wp_natural_path
+        (_expand_2d_path(node), node) for node in wp_natural_path
     ]:
         nodes_dict.setdefault(row_path, {})[col_path] = node
     graycode_order = _get_graycode_order(level, x="l", y="h")

--- a/tests/test_convolution_fwt.py
+++ b/tests/test_convolution_fwt.py
@@ -247,9 +247,10 @@ def test_conv_fwt():
 def test_ripples_haar_lvl3():
     """Compute example from page 7 of Ripples in Mathematics, Jensen, la Cour-Harbo."""
 
-    class MyHaarFilterBank(object):
+    class _MyHaarFilterBank(object):
         @property
         def filter_bank(self):
+            """Unscaled Haar wavelet filters."""
             return (
                 [1 / 2, 1 / 2.0],
                 [-1 / 2.0, 1 / 2.0],
@@ -258,7 +259,7 @@ def test_ripples_haar_lvl3():
             )
 
     data = torch.tensor([56.0, 40.0, 8.0, 24.0, 48.0, 48.0, 40.0, 16.0])
-    wavelet = pywt.Wavelet("unscaled Haar Wavelet", filter_bank=MyHaarFilterBank())
+    wavelet = pywt.Wavelet("unscaled Haar Wavelet", filter_bank=_MyHaarFilterBank())
     coeffs = wavedec(data, wavelet, level=3)
     assert torch.squeeze(coeffs[0]).numpy() == 35.0
     assert torch.squeeze(coeffs[1]).numpy() == -3.0

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -158,9 +158,10 @@ def test_packet_harbo_lvl3():
     """From Jensen, La Cour-Harbo, Rippels in Mathematics, Chapter 8 (page 89)."""
     data = np.array([56.0, 40.0, 8.0, 24.0, 48.0, 48.0, 40.0, 16.0])
 
-    class MyHaarFilterBank(object):
+    class _MyHaarFilterBank(object):
         @property
         def filter_bank(self):
+            """Unscaled Haar wavelet filters."""
             return (
                 [1 / 2, 1 / 2.0],
                 [-1 / 2.0, 1 / 2.0],
@@ -168,7 +169,7 @@ def test_packet_harbo_lvl3():
                 [1 / 2.0, -1 / 2.0],
             )
 
-    wavelet = pywt.Wavelet("unscaled Haar Wavelet", filter_bank=MyHaarFilterBank())
+    wavelet = pywt.Wavelet("unscaled Haar Wavelet", filter_bank=_MyHaarFilterBank())
 
     twp = WaveletPacket(torch.from_numpy(data), wavelet, mode="reflect")
     twp_nodes = twp.get_level(3)

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,42 @@ markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
 
 
+# config for coverage
+[coverage:run]
+branch = True
+cover_pylib = False
+source =
+    src/
+    tests/
+
+[coverage:report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+    # Don't complain about abstract methods, they aren't run:
+    @(abc\.)?abstractmethod
+skip_empty = true
+
+[coverage:html]
+directory = coverage_html_report
+skip_covered = true
+skip_empty = true
+
+
 [testenv:coverage-clean]
 deps = coverage
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,18 @@
 
 [tox]
 envlist =
+    coverage-clean
     flake8
     mypy
     py
+    docstr-coverage
+    coverage-report
 
 [testenv]
-commands = coverage run -p -m pytest -m "not slow" --durations=20 {posargs:tests} 
+commands =
+    coverage run -p -m pytest -m "not slow" --durations=20 {posargs:tests}
+    coverage combine
+    coverage xml
 deps =
     coverage
     pytest
@@ -20,6 +26,10 @@ markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
 
 
+[testenv:coverage-clean]
+deps = coverage
+skip_install = true
+commands = coverage erase
 
 [testenv:docstr-coverage]
 skip_install = true
@@ -61,6 +71,12 @@ commands =
     black src/ptwt/ examples/ tests/ setup.py
 description = Apply Black to python source code.
 
+
+[testenv:coverage-report]
+deps = coverage
+skip_install = true
+commands =
+    coverage report
 
 ####################
 # Deployment tools #

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ envlist =
 commands =
     coverage run -p -m pytest --durations=20 {posargs:-m "not slow" tests}
     coverage combine
-    coverage xml
 deps =
     coverage
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -114,6 +114,12 @@ skip_install = true
 commands =
     coverage report
 
+[testenv:coverage-html]
+deps = coverage
+skip_install = true
+commands =
+    coverage html
+
 ####################
 # Deployment tools #
 ####################

--- a/tox.ini
+++ b/tox.ini
@@ -96,7 +96,7 @@ description = Run the flake8 tool with several plugins (bandit, docstrings, impo
 
 [testenv:mypy]
 deps = mypy
-commands = mypy --ignore-missing-imports --strict --no-warn-return-any --implicit-reexport --allow-untyped-calls src/ptwt/
+commands = mypy --install-types --non-interactive --ignore-missing-imports --strict --no-warn-return-any --implicit-reexport --allow-untyped-calls src/ptwt/
 description = Run the mypy tool to check static typing on the project.
 
 [testenv:black]

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist =
 
 [testenv]
 commands =
-    coverage run -p -m pytest -m "not slow" --durations=20 {posargs:tests}
+    coverage run -p -m pytest --durations=20 {posargs:-m "not slow" tests}
     coverage combine
     coverage xml
 deps =


### PR DESCRIPTION
This prints a docstring coverage report and a general coverage report at the end of a `tox` run.

To show a coverage of all unit tests (including all marked as 'slow'), run `tox -e py tests`.