### PR TITLE
Separable conv transforms

### DIFF
--- a/src/ptwt/matmul_transform.py
+++ b/src/ptwt/matmul_transform.py
@@ -326,7 +326,8 @@ class MatrixWavedec(object):
             re_build = True
 
         if self.level is None:
-            self.level = int(np.log2(length))
+            wlen = len(self.wavelet)
+            self.level = int(np.log2(length / (wlen - 1)))
             re_build = True
         elif self.level <= 0:
             raise ValueError("level must be a positive integer.")

--- a/src/ptwt/matmul_transform_2.py
+++ b/src/ptwt/matmul_transform_2.py
@@ -216,7 +216,8 @@ class MatrixWavedec2(object):
         For longer wavelets, high level transforms, and large
         input images this may take a while.
         The matrix is therefore constructed only once.
-        It can be accessed via the sparse_fwt_operator property.
+        In the non separable case, it can be accessed via 
+        the sparse_fwt_operator property.
 
     Example:
         >>> import ptwt, torch, pywt

--- a/src/ptwt/matmul_transform_2.py
+++ b/src/ptwt/matmul_transform_2.py
@@ -438,7 +438,10 @@ class MatrixWavedec2(object):
             re_build = True
 
         if self.level is None:
-            self.level = int(np.min([np.log2(height), np.log2(width)]))
+            wlen = len(self.wavelet)
+            self.level = int(
+                np.min([np.log2(height / (wlen - 1)), np.log2(width / (wlen - 1))])
+            )
             re_build = True
         elif self.level <= 0:
             raise ValueError("level must be a positive integer.")

--- a/src/ptwt/matmul_transform_2.py
+++ b/src/ptwt/matmul_transform_2.py
@@ -216,7 +216,7 @@ class MatrixWavedec2(object):
         For longer wavelets, high level transforms, and large
         input images this may take a while.
         The matrix is therefore constructed only once.
-        In the non separable case, it can be accessed via 
+        In the non separable case, it can be accessed via
         the sparse_fwt_operator property.
 
     Example:
@@ -253,10 +253,10 @@ class MatrixWavedec2(object):
                 Choose 'gramschmidt' if 'qr' runs out of memory.
                 Defaults to 'qr'.
             separable (bool): If this flag is set, a separable transformation
-                is used, i.e. a 1d transformation along each axis. 
-                Matrix construction is significantly faster for separable transformations
-                since only a small constant-size part of the matrices must be orthogonalized.
-                Defaults to True.
+                is used, i.e. a 1d transformation along each axis.
+                Matrix construction is significantly faster for separable
+                transformations since only a small constant-size part of the
+                matrices must be orthogonalized. Defaults to True.
 
         Raises:
             NotImplementedError: If the selected `boundary` mode is not supported.

--- a/src/ptwt/matmul_transform_2.py
+++ b/src/ptwt/matmul_transform_2.py
@@ -252,9 +252,10 @@ class MatrixWavedec2(object):
                 Choose 'gramschmidt' if 'qr' runs out of memory.
                 Defaults to 'qr'.
             separable (bool): If this flag is set, a separable transformation
-                is used, i.e. a 1d transformation along each axis. This is significantly
-                faster than a non-separable transformation since only a small constant-
-                size part of the matrices must be orthogonalized. Defaults to True.
+                is used, i.e. a 1d transformation along each axis. 
+                Matrix construction is significantly faster for separable transformations
+                since only a small constant-size part of the matrices must be orthogonalized.
+                Defaults to True.
 
         Raises:
             NotImplementedError: If the selected `boundary` mode is not supported.

--- a/src/ptwt/matmul_transform_3.py
+++ b/src/ptwt/matmul_transform_3.py
@@ -48,6 +48,9 @@ class MatrixWavedec3(object):
     ):
         """Create a *separable* three-dimensional fast boundary wavelet transform.
 
+        Input signals should have the shape [batch_size, depth, height, width],
+        this object transforms the last three dimensions.
+
         Args:
             wavelet (Union[Wavelet, str]): The wavelet to use.
             level (Optional[int]): The desired decomposition level.

--- a/src/ptwt/matmul_transform_3.py
+++ b/src/ptwt/matmul_transform_3.py
@@ -176,7 +176,16 @@ class MatrixWavedec3(object):
             re_build = True
 
         if self.level is None:
-            self.level = int(np.min([np.log2(depth), np.log2(height), np.log2(width)]))
+            wlen = len(self.wavelet)
+            self.level = int(
+                np.min(
+                    [
+                        np.log2(depth / (wlen - 1)),
+                        np.log2(height / (wlen - 1)),
+                        np.log2(width / (wlen - 1)),
+                    ]
+                )
+            )
             re_build = True
         elif self.level <= 0:
             raise ValueError("level must be a positive integer.")

--- a/src/ptwt/matmul_transform_3.py
+++ b/src/ptwt/matmul_transform_3.py
@@ -392,7 +392,6 @@ class MatrixWaverec3(object):
                         done_dict[a_key[1:]] = cat_tensor
                     else:
                         return cat_tensor
-
                 return _cat_coeff_recursive(done_dict)
 
             coeff_dict["a" * len(list(coeff_dict.keys())[-1])] = ll

--- a/src/ptwt/matmul_transform_3.py
+++ b/src/ptwt/matmul_transform_3.py
@@ -13,8 +13,8 @@ from .matmul_transform import construct_boundary_a, construct_boundary_s
 from .sparse_math import _batch_dim_mm
 
 
-class PadTuple(NamedTuple):
-    """Replaces PadTuple = namedtuple("PadTuple", ("depth", "height", "width"))."""
+class _PadTuple(NamedTuple):
+    """Replaces _PadTuple = namedtuple("_PadTuple", ("depth", "height", "width"))."""
 
     depth: bool
     height: bool
@@ -23,7 +23,7 @@ class PadTuple(NamedTuple):
 
 def _matrix_pad_3(
     depth: int, height: int, width: int
-) -> Tuple[int, int, int, PadTuple]:
+) -> Tuple[int, int, int, _PadTuple]:
     pad_depth, pad_height, pad_width = (False, False, False)
     if height % 2 != 0:
         height += 1
@@ -34,7 +34,7 @@ def _matrix_pad_3(
     if depth % 2 != 0:
         depth += 1
         pad_depth = True
-    return depth, height, width, PadTuple(pad_depth, pad_height, pad_width)
+    return depth, height, width, _PadTuple(pad_depth, pad_height, pad_width)
 
 
 class MatrixWavedec3(object):

--- a/src/ptwt/separable_conv_transform.py
+++ b/src/ptwt/separable_conv_transform.py
@@ -4,15 +4,41 @@ Under the hood code in this module transforms all dimensions
 individually using torch.nn.functional.conv1d and it's
 transpose.
 """
-# from typing import Union
+from typing import Dict, List, Optional, Union
+
+import numpy as np
+import pywt
+import torch
 
 from src.ptwt.conv_transform import wavedec, waverec
 
 
-def _separable_conv_dwtn_(input, wavelet, mode, key, dict) -> None:
+def _separable_conv_dwtn_(
+    rec_dict: Dict[str, torch.Tensor],
+    input: torch.Tensor,
+    wavelet: Union[str, pywt.Wavelet],
+    mode: str = "reflect",
+    key: str = "",
+) -> None:
+    """Compute a single level separable fast wavelet transform.
+
+    All but the first axes are transformed.
+
+    Args:
+        input (torch.Tensor): Tensor of shape [batch, data_1, ... data_n].
+        wavelet (Union[str, pywt.Wavelet]): The Wavelet to work with.
+        mode (str): The padding mode. The following methods are supported::
+
+                "reflect", "zero", "constant", "periodic".
+
+            Defaults to "reflect".
+        key (str): The filter application path. Defaults to "".
+        dict (Dict[str, torch.Tensor]): The result will be stored here
+            in place. Defaults to {}.
+    """
     axis_total = len(input.shape) - 1
     if len(key) == axis_total:
-        dict[key] = input
+        rec_dict[key] = input
     if len(key) < axis_total:
         current_axis = len(key) + 1
         transposed = input.transpose(-current_axis, -1)
@@ -22,11 +48,24 @@ def _separable_conv_dwtn_(input, wavelet, mode, key, dict) -> None:
         res_d = res_d.reshape(list(transposed.shape[:-1]) + [res_d.shape[-1]])
         res_a = res_a.transpose(-1, -current_axis)
         res_d = res_d.transpose(-1, -current_axis)
-        _separable_conv_dwtn_(res_a, wavelet, mode, "a" + key, dict)
-        _separable_conv_dwtn_(res_d, wavelet, mode, "d" + key, dict)
+        _separable_conv_dwtn_(rec_dict, res_a, wavelet, mode, "a" + key)
+        _separable_conv_dwtn_(rec_dict, res_d, wavelet, mode, "d" + key)
 
 
-def _separable_conv_idwtn(in_dict, wavelet):
+def _separable_conv_idwtn(
+    in_dict: Dict[str, torch.Tensor], wavelet: Union[str, pywt.Wavelet]
+) -> torch.Tensor:
+    """Separable single level inverse fast wavelet transform.
+
+    Args:
+        in_dict (Dict[str, torch.Tensor]): The dictionary produced
+            by _separable_conv_dwtn_ .
+        wavelet (Union[str, pywt.Wavelet]): The wavelet used by
+            _separable_conv_dwtn_ .
+
+    Returns:
+        torch.Tensor: A reconstruction of the original signal.
+    """
     done_dict = {}
     a_initial_keys = list(filter(lambda x: x[0] == "a", in_dict.keys()))
     for a_key in a_initial_keys:
@@ -42,7 +81,7 @@ def _separable_conv_idwtn(in_dict, wavelet):
         flat_a, flat_d = (
             coeff.reshape(-1, coeff.shape[-1]) for coeff in (trans_a, trans_d)
         )
-        rec_ad = waverec((flat_a, flat_d), wavelet)
+        rec_ad = waverec([flat_a, flat_d], wavelet)
         rec_ad = rec_ad.reshape(list(trans_a.shape[:-1]) + [rec_ad.shape[-1]])
         rec_ad = rec_ad.transpose(-current_axis, -1)
         if a_key[1:]:
@@ -52,23 +91,80 @@ def _separable_conv_idwtn(in_dict, wavelet):
     return _separable_conv_idwtn(done_dict, wavelet)
 
 
-def _separable_conv_waverecn(coeff_list, wavelet):
-    approx = coeff_list[0]
-    for level_dict in coeff_list[1:]:
-        keys = list(level_dict.keys())
-        level_dict["a" * max(map(len, keys))] = approx
-        approx = _separable_conv_idwtn(level_dict, wavelet)
-    return approx
+def _separable_conv_wavedecn(
+    input: torch.Tensor,
+    wavelet: Union[str, pywt.Wavelet],
+    mode: str = "reflect",
+    level: Optional[int] = None,
+) -> List[Union[torch.Tensor, Dict[str, torch.Tensor]]]:
+    """Compute a multilevel separable padded wavelet analysis transform.
 
+    Args:
+        input (torch.Tensor): A tensor of shap [batch, axis_1, ... axis_n].
+            Everything but the batch axis will be transformed.
+        wavelet (Union[str, pywt.Wavelet]): The desired wavelet.
 
-def _separable_conv_wavedecn(input, wavelet, mode, levels):
-    result = []
+        wavelet (Wavelet or str): A pywt wavelet compatible object or
+            the name of a pywt wavelet.
+            Please consider the output from ``pywt.wavelist(kind='discrete')``
+            for possible choices.
+        mode (str): The desired padding mode. Padding extends the signal along
+            the edges. Supported methods are::
+
+                "reflect", "zero", "constant", "periodic".
+
+            Defaults to "reflect".
+        level (int): The desired decomposition level. If None the
+            largest possible decomposition value is used.
+
+    Returns:
+        List[Union[torch.Tensor, Dict[str, torch.Tensor]]]: _description_
+    """
+    result: List[Union[torch.Tensor, Dict[str, torch.Tensor]]] = []
     approx = input
-    for _ in range(levels):
-        level_dict = {}
-        _separable_conv_dwtn_(approx, wavelet, mode, "", level_dict)
+
+    if level is None:
+        wlen = len(wavelet)
+        level = int(
+            min([np.log2(axis_len / (wlen - 1)) for axis_len in input.shape[1:]])
+        )
+
+    for _ in range(level):
+        level_dict: Dict[str, torch.Tensor] = {}
+        _separable_conv_dwtn_(level_dict, approx, wavelet, mode, "")
         approx_key = "a" * (len(input.shape) - 1)
         approx = level_dict.pop(approx_key)
         result.append(level_dict)
     result.append(approx)
     return result[::-1]
+
+
+def _separable_conv_waverecn(
+    coeff_list: List[Union[torch.Tensor, Dict[str, torch.Tensor]]],
+    wavelet: Union[str, pywt.Wavelet],
+) -> torch.Tensor:
+    """Separable n-dimensional wavelet synthesis transform.
+
+    Args:
+        coeff_list (List[Union[torch.Tensor, Dict[str, torch.Tensor]]]):
+            The output as produces by _separable_conv_wavedecn.
+        wavelet (Union[str, pywt.Wavelet]):
+            The wavelet used by _separable_conv_wavedecn.
+
+    Returns:
+        torch.Tensor: The reconstruction of the original signal.
+
+    Raises:
+        ValueError: If the coeff_list is no not structured as expected.
+    """
+    if not isinstance(coeff_list[0], torch.Tensor):
+        raise ValueError("approximation tensor must be first in coefficient list.")
+    if not all(map(lambda x: isinstance(x, dict), coeff_list[1:])):
+        raise ValueError("All entries after approximation tensor must be dicts.")
+
+    approx: torch.Tensor = coeff_list[0]
+    for level_dict in coeff_list[1:]:
+        keys = list(level_dict.keys())  # type: ignore
+        level_dict["a" * max(map(len, keys))] = approx  # type: ignore
+        approx = _separable_conv_idwtn(level_dict, wavelet)  # type: ignore
+    return approx

--- a/src/ptwt/separable_conv_transform.py
+++ b/src/ptwt/separable_conv_transform.py
@@ -4,19 +4,71 @@ Under the hood code in this module transforms all dimensions
 individually using torch.nn.functional.conv1d and it's
 transpose.
 """
-from typing import Union
+# from typing import Union
 
-import pywt
-import torch
-from _util import _as_wavelet
+from src.ptwt.conv_transform import wavedec, waverec
 
 
-def fswavedec2(
-    data: torch.Tensor,
-    wavelet: Union[str, pywt.Wavelet],
-    mode: str = "symmetric",
-    levels: int = None,
-):
-    """Two dimensional fully separable transform."""
-    wavelet = _as_wavelet(wavelet)
-    return None
+def _separable_conv_dwtn_(input, wavelet, mode, key, dict) -> None:
+    axis_total = len(input.shape) - 1
+    if len(key) == axis_total:
+        dict[key] = input
+    if len(key) < axis_total:
+        current_axis = len(key) + 1
+        transposed = input.transpose(-current_axis, -1)
+        flat = transposed.reshape(-1, transposed.shape[-1])
+        res_a, res_d = wavedec(flat, wavelet, 1, mode)
+        res_a = res_a.reshape(list(transposed.shape[:-1]) + [res_a.shape[-1]])
+        res_d = res_d.reshape(list(transposed.shape[:-1]) + [res_d.shape[-1]])
+        res_a = res_a.transpose(-1, -current_axis)
+        res_d = res_d.transpose(-1, -current_axis)
+        _separable_conv_dwtn_(res_a, wavelet, mode, "a" + key, dict)
+        _separable_conv_dwtn_(res_d, wavelet, mode, "d" + key, dict)
+
+
+def _separable_conv_idwtn(in_dict, wavelet):
+    done_dict = {}
+    a_initial_keys = list(filter(lambda x: x[0] == "a", in_dict.keys()))
+    for a_key in a_initial_keys:
+        current_axis = len(a_key)
+        d_key = "d" + a_key[1:]
+        coeff_d = in_dict[d_key]
+        d_shape = coeff_d.shape
+        # undo any analysis padding.
+        coeff_a = in_dict[a_key][tuple(slice(0, ds) for ds in d_shape)]
+        trans_a, trans_d = (
+            coeff.transpose(-1, -current_axis) for coeff in (coeff_a, coeff_d)
+        )
+        flat_a, flat_d = (
+            coeff.reshape(-1, coeff.shape[-1]) for coeff in (trans_a, trans_d)
+        )
+        rec_ad = waverec((flat_a, flat_d), wavelet)
+        rec_ad = rec_ad.reshape(list(trans_a.shape[:-1]) + [rec_ad.shape[-1]])
+        rec_ad = rec_ad.transpose(-current_axis, -1)
+        if a_key[1:]:
+            done_dict[a_key[1:]] = rec_ad
+        else:
+            return rec_ad
+    return _separable_conv_idwtn(done_dict, wavelet)
+
+
+def _separable_conv_waverecn(coeff_list, wavelet):
+    approx = coeff_list[0]
+    for level_dict in coeff_list[1:]:
+        keys = list(level_dict.keys())
+        level_dict["a" * max(map(len, keys))] = approx
+        approx = _separable_conv_idwtn(level_dict, wavelet)
+    return approx
+
+
+def _separable_conv_wavedecn(input, wavelet, mode, levels):
+    result = []
+    approx = input
+    for _ in range(levels):
+        level_dict = {}
+        _separable_conv_dwtn_(approx, wavelet, mode, "", level_dict)
+        approx_key = "a" * (len(input.shape) - 1)
+        approx = level_dict.pop(approx_key)
+        result.append(level_dict)
+    result.append(approx)
+    return result[::-1]

--- a/src/ptwt/separable_conv_transform.py
+++ b/src/ptwt/separable_conv_transform.py
@@ -1,0 +1,22 @@
+"""Implement separable convolution based transforms.
+
+Under the hood code in this module transforms all dimensions
+individually using torch.nn.functional.conv1d and it's
+transpose.
+"""
+from typing import Union
+
+import pywt
+import torch
+from _util import _as_wavelet
+
+
+def fswavedec(
+    data: torch.Tensor,
+    wavelet: Union[str, pywt.Wavelet],
+    mode: str = "symmetric",
+    levels: int = None,
+):
+
+    wavelet = _as_wavelet(wavelet)
+    return None

--- a/src/ptwt/separable_conv_transform.py
+++ b/src/ptwt/separable_conv_transform.py
@@ -11,12 +11,12 @@ import torch
 from _util import _as_wavelet
 
 
-def fswavedec(
+def fswavedec2(
     data: torch.Tensor,
     wavelet: Union[str, pywt.Wavelet],
     mode: str = "symmetric",
     levels: int = None,
 ):
-
+    """Two dimensional fully separable transform."""
     wavelet = _as_wavelet(wavelet)
     return None

--- a/tests/test_separable_conv_fwt.py
+++ b/tests/test_separable_conv_fwt.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pytest
+import pywt
+import torch
+
+from src.ptwt.conv_transform import wavedec
+
+
+def _separable_conv_dwtn_(input, wavelet, mode, key, dict) -> None:
+    axis_total = len(input.shape) - 1
+    if len(key) < axis_total:
+        current_axis = len(key) + 1
+        transposed = input.transpose(current_axis, -1)
+        flat = transposed.reshape(-1, transposed.shape[-1])
+        res_a, res_d = wavedec(flat, wavelet, 1, mode)
+        res_a = res_a.reshape(list(transposed.shape[:-1]) + [res_a.shape[-1]])
+        res_d = res_d.reshape(list(transposed.shape[:-1]) + [res_d.shape[-1]])
+        res_a = res_a.transpose(-1, current_axis)
+        res_d = res_d.transpose(-1, current_axis)
+        _separable_conv_dwtn_(res_a, wavelet, mode, "a" + key, dict)
+        _separable_conv_dwtn_(res_a, wavelet, mode, "d" + key, dict)
+    else:
+        dict[key] = input
+
+
+def _separable_conv_wavedecn(input, wavelet, mode, levels):
+    result = []
+    approx = input
+    for _ in range(levels):
+        level_dict = {}
+        _separable_conv_dwtn_(approx, wavelet, mode, "", level_dict)
+        approx_key = "a" * (len(input.shape) - 1)
+        approx = level_dict.pop(approx_key)
+        result.append(level_dict)
+    result.append(approx)
+    return result
+
+
+def test_separable_conv() -> None:
+
+    data = np.random.randint(0, 9, (12, 12))
+
+    result = pywt.fswavedecn(data, "haar", levels=2)
+    detail_keys = result.detail_keys()
+    approx = result.approx
+    details = [result[key] for key in detail_keys]
+
+    pt_data = torch.from_numpy(data).unsqueeze(0).type(torch.float32)
+    ptwt_res = _separable_conv_wavedecn(pt_data, "haar", mode="reflect", levels=2)
+
+    # TODO: test results.
+    pass

--- a/tests/test_separable_conv_fwt.py
+++ b/tests/test_separable_conv_fwt.py
@@ -1,3 +1,5 @@
+"""Separable transform test code."""
+
 import numpy as np
 import pytest
 import pywt
@@ -18,7 +20,7 @@ def _separable_conv_dwtn_(input, wavelet, mode, key, dict) -> None:
         res_a = res_a.transpose(-1, current_axis)
         res_d = res_d.transpose(-1, current_axis)
         _separable_conv_dwtn_(res_a, wavelet, mode, "a" + key, dict)
-        _separable_conv_dwtn_(res_a, wavelet, mode, "d" + key, dict)
+        _separable_conv_dwtn_(res_d, wavelet, mode, "d" + key, dict)
     else:
         dict[key] = input
 
@@ -33,20 +35,37 @@ def _separable_conv_wavedecn(input, wavelet, mode, levels):
         approx = level_dict.pop(approx_key)
         result.append(level_dict)
     result.append(approx)
-    return result
+    return result[::-1]
 
 
-def test_separable_conv() -> None:
-
-    data = np.random.randint(0, 9, (12, 12))
+@pytest.mark.parametrize("shape", ((12, 12), (12, 12, 12), (12, 24, 12)))
+def test_separable_conv(shape) -> None:
+    """Test the separable transforms."""
+    data = np.random.randint(0, 9, shape)
 
     result = pywt.fswavedecn(data, "haar", levels=2)
     detail_keys = result.detail_keys()
     approx = result.approx
     details = [result[key] for key in detail_keys]
+    flat_pywt_res = [approx]
+    flat_pywt_res.extend(details)
 
-    pt_data = torch.from_numpy(data).unsqueeze(0).type(torch.float32)
+    pt_data = torch.from_numpy(data).unsqueeze(0).type(torch.float64)
     ptwt_res = _separable_conv_wavedecn(pt_data, "haar", mode="reflect", levels=2)
+    ptwt_res_lists = [ptwt_res[0]]
+    ptwt_res_lists.extend(
+        [tensor for ptwt_dict in ptwt_res[1:] for _, tensor in ptwt_dict.items()]
+    )
+    flat_ptwt_res = [
+        tensor.numpy() for tensor_list in ptwt_res_lists for tensor in tensor_list
+    ]
 
-    # TODO: test results.
+    pywt_fine_scale = list(filter(lambda x: x.shape == approx.shape, flat_pywt_res))
+    assert all(
+        [
+            np.allclose(ptwt_tensor, pywt_array)
+            for ptwt_tensor, pywt_array in zip(flat_ptwt_res, pywt_fine_scale)
+        ]
+    )
+
     pass

--- a/tests/test_separable_conv_fwt.py
+++ b/tests/test_separable_conv_fwt.py
@@ -5,45 +5,21 @@ import pytest
 import pywt
 import torch
 
-from src.ptwt.conv_transform import wavedec
+from src.ptwt.separable_conv_transform import (
+    _separable_conv_wavedecn,
+    _separable_conv_waverecn,
+)
 
 
-def _separable_conv_dwtn_(input, wavelet, mode, key, dict) -> None:
-    axis_total = len(input.shape) - 1
-    if len(key) < axis_total:
-        current_axis = len(key) + 1
-        transposed = input.transpose(current_axis, -1)
-        flat = transposed.reshape(-1, transposed.shape[-1])
-        res_a, res_d = wavedec(flat, wavelet, 1, mode)
-        res_a = res_a.reshape(list(transposed.shape[:-1]) + [res_a.shape[-1]])
-        res_d = res_d.reshape(list(transposed.shape[:-1]) + [res_d.shape[-1]])
-        res_a = res_a.transpose(-1, current_axis)
-        res_d = res_d.transpose(-1, current_axis)
-        _separable_conv_dwtn_(res_a, wavelet, mode, "a" + key, dict)
-        _separable_conv_dwtn_(res_d, wavelet, mode, "d" + key, dict)
-    else:
-        dict[key] = input
-
-
-def _separable_conv_wavedecn(input, wavelet, mode, levels):
-    result = []
-    approx = input
-    for _ in range(levels):
-        level_dict = {}
-        _separable_conv_dwtn_(approx, wavelet, mode, "", level_dict)
-        approx_key = "a" * (len(input.shape) - 1)
-        approx = level_dict.pop(approx_key)
-        result.append(level_dict)
-    result.append(approx)
-    return result[::-1]
-
-
-@pytest.mark.parametrize("shape", ((12, 12), (12, 12, 12), (12, 24, 12)))
-def test_separable_conv(shape) -> None:
+@pytest.mark.parametrize("level", (1, 2))
+@pytest.mark.parametrize(
+    "shape", ((12, 12), (24, 12, 12), (12, 24, 12), (12, 12, 12, 12))
+)
+def test_separable_conv(shape, level) -> None:
     """Test the separable transforms."""
     data = np.random.randint(0, 9, shape)
 
-    result = pywt.fswavedecn(data, "haar", levels=2)
+    result = pywt.fswavedecn(data, "haar", levels=level)
     detail_keys = result.detail_keys()
     approx = result.approx
     details = [result[key] for key in detail_keys]
@@ -51,10 +27,16 @@ def test_separable_conv(shape) -> None:
     flat_pywt_res.extend(details)
 
     pt_data = torch.from_numpy(data).unsqueeze(0).type(torch.float64)
-    ptwt_res = _separable_conv_wavedecn(pt_data, "haar", mode="reflect", levels=2)
+    ptwt_res = _separable_conv_wavedecn(pt_data, "haar", mode="reflect", levels=level)
     ptwt_res_lists = [ptwt_res[0]]
+    # product a proper order.
     ptwt_res_lists.extend(
-        [tensor for ptwt_dict in ptwt_res[1:] for _, tensor in ptwt_dict.items()]
+        [
+            ptwt_dict[key]
+            for ptwt_dict in ptwt_res[1:]
+            for key in sorted(ptwt_dict.keys())
+            if len(key) == len(shape)
+        ]
     )
     flat_ptwt_res = [
         tensor.numpy() for tensor_list in ptwt_res_lists for tensor in tensor_list
@@ -63,9 +45,13 @@ def test_separable_conv(shape) -> None:
     pywt_fine_scale = list(filter(lambda x: x.shape == approx.shape, flat_pywt_res))
     assert all(
         [
-            np.allclose(ptwt_tensor, pywt_array)
-            for ptwt_tensor, pywt_array in zip(flat_ptwt_res, pywt_fine_scale)
+            np.allclose(ptwt_array, pywt_array)
+            for ptwt_array, pywt_array in zip(flat_ptwt_res, pywt_fine_scale)
         ]
     )
 
-    pass
+    rec = _separable_conv_waverecn(ptwt_res, "haar")
+    assert np.allclose(rec.numpy(), data)
+
+
+# TODO: Test padding!!!

--- a/tests/test_separable_conv_fwt.py
+++ b/tests/test_separable_conv_fwt.py
@@ -27,7 +27,7 @@ def test_separable_conv(shape, level) -> None:
     flat_pywt_res.extend(details)
 
     pt_data = torch.from_numpy(data).unsqueeze(0).type(torch.float64)
-    ptwt_res = _separable_conv_wavedecn(pt_data, "haar", mode="reflect", levels=level)
+    ptwt_res = _separable_conv_wavedecn(pt_data, "haar", mode="reflect", level=level)
     ptwt_res_lists = [ptwt_res[0]]
     # product a proper order.
     ptwt_res_lists.extend(


### PR DESCRIPTION
- implement padded separable convolutions.
- all boundary wavelet transforms now compute the max-level correctly if `level` is set to `None`.