### PR TITLE
Use typing.Literal for boundary mode, padding mode, and orthogonalization mode

### DIFF
--- a/docs/ptwt.rst
+++ b/docs/ptwt.rst
@@ -102,4 +102,9 @@ ptwt.wavelets\_learnable module
    :undoc-members:
    :show-inheritance:
 
-
+ptwt.constants
+-------------------------------
+.. automodule:: ptwt.constants
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/examples/speed_tests/timeitconv_2d.py
+++ b/examples/speed_tests/timeitconv_2d.py
@@ -32,7 +32,7 @@ def _to_jit_wavedec_2(data, wavelet):
     means we have to stack the lists in the output.
     """
     assert data.shape == (32, 1e3, 1e3), "Changing the chape requires re-tracing."
-    coeff = ptwt.wavedec2(data, wavelet, "periodic", level=5)
+    coeff = ptwt.wavedec2(data, wavelet, mode="periodic", level=5)
     coeff2 = []
     for c in coeff:
         if isinstance(c, torch.Tensor):

--- a/src/ptwt/_util.py
+++ b/src/ptwt/_util.py
@@ -1,9 +1,13 @@
 """Utility methods to compute wavelet decompositions from a dataset."""
+
+import typing
 from typing import Any, Callable, List, Optional, Protocol, Sequence, Tuple, Union
 
 import numpy as np
 import pywt
 import torch
+
+from ptwt.constants import OrthogonalizeMethod
 
 
 class Wavelet(Protocol):
@@ -42,8 +46,8 @@ def _as_wavelet(wavelet: Union[Wavelet, str]) -> Wavelet:
         return wavelet
 
 
-def _is_boundary_mode_supported(boundary_mode: Optional[str]) -> bool:
-    return boundary_mode in ["qr", "gramschmidt"]
+def _is_boundary_mode_supported(boundary_mode: Optional[OrthogonalizeMethod]) -> bool:
+    return boundary_mode in typing.get_args(OrthogonalizeMethod)
 
 
 def _is_dtype_supported(dtype: torch.dtype) -> bool:

--- a/src/ptwt/constants.py
+++ b/src/ptwt/constants.py
@@ -14,5 +14,5 @@ This is a type literal for the way of padding.
 - Zero padding pads zeros.
 - Constant padding replicates border values.
 - Periodic padding cyclically repeats samples.
-- Symmetric padding does ..todo:: moritz, write this!
+- Symmetric padding mirrors samples along the border
 """

--- a/src/ptwt/constants.py
+++ b/src/ptwt/constants.py
@@ -4,6 +4,8 @@ from typing import Literal
 
 __all__ = [
     "BoundaryMode",
+    "Conv2DMode",
+    "OrthogonalizeMethod",
 ]
 
 BoundaryMode = Literal["constant", "zero", "reflect", "periodic", "symmetric"]
@@ -16,3 +18,7 @@ This is a type literal for the way of padding.
 - Periodic padding cyclically repeats samples.
 - Symmetric padding mirrors samples along the border
 """
+
+Conv2DMode = Literal["full", "valid", "same", "sameshift"]
+
+OrthogonalizeMethod = Literal["qr", "gramschmidt"]

--- a/src/ptwt/constants.py
+++ b/src/ptwt/constants.py
@@ -1,0 +1,18 @@
+"""Constants and types used throughout the PyTorch Wavelet Toolbox."""
+
+from typing import Literal
+
+__all__ = [
+    "BoundaryMode",
+]
+
+BoundaryMode = Literal["constant", "zero", "reflect", "periodic", "symmetric"]
+"""
+This is a type literal for the way of padding.
+
+- Refection padding mirrors samples along the border.
+- Zero padding pads zeros.
+- Constant padding replicates border values.
+- Periodic padding cyclically repeats samples.
+- Symmetric padding does ..todo:: moritz, write this!
+"""

--- a/src/ptwt/constants.py
+++ b/src/ptwt/constants.py
@@ -1,9 +1,10 @@
 """Constants and types used throughout the PyTorch Wavelet Toolbox."""
 
-from typing import Literal
+from typing import Literal, Union
 
 __all__ = [
     "BoundaryMode",
+    "ExtendedBoundaryMode",
     "Conv2DMode",
     "OrthogonalizeMethod",
 ]
@@ -18,6 +19,8 @@ This is a type literal for the way of padding.
 - Periodic padding cyclically repeats samples.
 - Symmetric padding mirrors samples along the border
 """
+
+ExtendedBoundaryMode = Union[Literal["boundary"], BoundaryMode]
 
 Conv2DMode = Literal["full", "valid", "same", "sameshift"]
 

--- a/src/ptwt/constants.py
+++ b/src/ptwt/constants.py
@@ -32,7 +32,7 @@ OrthogonalizeMethod = Literal["qr", "gramschmidt"]
 The method for orthogonalizing a matrix.
 
 1. 'qr' relies on pytorch's dense qr implementation, it is fast but memory hungry.
-2. 'gramschmidt' option is sparse, memory efficient, and slow. 
+2. 'gramschmidt' option is sparse, memory efficient, and slow.
 
 Choose 'gramschmidt' if 'qr' runs out of memory.
 """

--- a/src/ptwt/constants.py
+++ b/src/ptwt/constants.py
@@ -5,7 +5,7 @@ from typing import Literal, Union
 __all__ = [
     "BoundaryMode",
     "ExtendedBoundaryMode",
-    "Conv2DMode",
+    "PaddingMode",
     "OrthogonalizeMethod",
 ]
 
@@ -22,6 +22,17 @@ This is a type literal for the way of padding.
 
 ExtendedBoundaryMode = Union[Literal["boundary"], BoundaryMode]
 
-Conv2DMode = Literal["full", "valid", "same", "sameshift"]
+PaddingMode = Literal["full", "valid", "same", "sameshift"]
+"""
+The padding mode is used when construction convolution matrices.
+"""
 
 OrthogonalizeMethod = Literal["qr", "gramschmidt"]
+"""
+The method for orthogonalizing a matrix.
+
+1. 'qr' relies on pytorch's dense qr implementation, it is fast but memory hungry.
+2. 'gramschmidt' option is sparse, memory efficient, and slow. 
+
+Choose 'gramschmidt' if 'qr' runs out of memory.
+"""

--- a/src/ptwt/conv_transform.py
+++ b/src/ptwt/conv_transform.py
@@ -129,7 +129,7 @@ def _translate_boundary_strings(pywt_mode: BoundaryMode) -> str:
         # pytorch does not support symmetric mode,
         # we have our own implementation.
         return pywt_mode
-    raise TypeError("Padding mode not supported.")
+    raise TypeError(f"Padding mode not supported: {pywt_mode}")
 
 
 def _fwt_pad(

--- a/src/ptwt/conv_transform.py
+++ b/src/ptwt/conv_transform.py
@@ -146,13 +146,9 @@ def _fwt_pad(
         data (torch.Tensor): Input data ``[batch_size, 1, time]``
         wavelet (Wavelet or str): A pywt wavelet compatible object or
             the name of a pywt wavelet.
-        mode : The desired way to pad. The following methods are supported::
-
-            1. Refection padding mirrors samples along the border (default)
-            2. Zero padding pads zeros.
-            3. Constant padding replicates border values.
-            4. Periodic padding cyclically repeats samples.
-            5. ...
+        mode :
+            The desired padding mode for extending the signal along the edges.
+            Defaults to "reflect". See :data:`ptwt.constants.BoundaryMode`.
 
     Returns:
         torch.Tensor: A PyTorch tensor with the padded input data
@@ -279,18 +275,9 @@ def wavedec(
             the name of a pywt wavelet.
             Please consider the output from ``pywt.wavelist(kind='discrete')``
             for possible choices.
-        mode : The desired padding mode. Padding extends the signal along
-            the edges. Supported methods are::
-
-                "reflect", "zero", "constant", "periodic", "symmetric".
-
-            Defaults to "reflect".
-
-            Symmetric padding mirrors samples along the border.
-            Refection padding reflects samples along the border.
-            Zero padding pads zeros.
-            Constant padding replicates border values.
-            Periodic padding cyclically repeats samples.
+        mode :
+            The desired padding mode for extending the signal along the edges.
+            Defaults to "reflect". See :data:`ptwt.constants.BoundaryMode`.
         level (int): The scale level to be computed.
                                Defaults to None.
         axis (int): Compute the transform over this axis instead of the

--- a/src/ptwt/conv_transform.py
+++ b/src/ptwt/conv_transform.py
@@ -114,7 +114,7 @@ def _translate_boundary_strings(pywt_mode: BoundaryMode) -> str:
     Pytorch and PyWavelet communities.
 
     Raises:
-        TypeError: If the padding mode is not supported.
+        ValueError: If the padding mode is not supported.
 
     """
     if pywt_mode == "constant":
@@ -129,7 +129,7 @@ def _translate_boundary_strings(pywt_mode: BoundaryMode) -> str:
         # pytorch does not support symmetric mode,
         # we have our own implementation.
         return pywt_mode
-    raise TypeError(f"Padding mode not supported: {pywt_mode}")
+    raise ValueError(f"Padding mode not supported: {pywt_mode}")
 
 
 def _fwt_pad(

--- a/src/ptwt/conv_transform_2.py
+++ b/src/ptwt/conv_transform_2.py
@@ -131,6 +131,7 @@ def _preprocess_tensor_dec2d(
 def wavedec2(
     data: torch.Tensor,
     wavelet: Union[Wavelet, str],
+    *,
     mode: BoundaryMode = "reflect",
     level: Optional[int] = None,
     axes: Tuple[int, int] = (-2, -1),

--- a/src/ptwt/conv_transform_2.py
+++ b/src/ptwt/conv_transform_2.py
@@ -73,12 +73,9 @@ def _fwt_pad2(
         data (torch.Tensor): Input data with 4 dimensions.
         wavelet (Wavelet or str): A pywt wavelet compatible object or
             the name of a pywt wavelet.
-        mode (str): The padding mode.
-            Supported modes are::
-
-                "reflect", "zero", "constant", "periodic", "symmetric".
-
-            "reflect" is the default mode.
+        mode :
+            The desired padding mode for extending the signal along the edges.
+            Defaults to "reflect". See :data:`ptwt.constants.BoundaryMode`.
 
     Returns:
         The padded output tensor.
@@ -150,11 +147,9 @@ def wavedec2(
         wavelet (Wavelet or str): A pywt wavelet compatible object or
             the name of a pywt wavelet. Refer to the output of
             ``pywt.wavelist(kind="discrete")`` for a list of possible choices.
-        mode : The padding mode. Options are::
-
-                "reflect", "zero", "constant", "periodic", "symmetric".
-
-            This function defaults to "reflect".
+        mode :
+            The desired padding mode for extending the signal along the edges.
+            Defaults to "reflect". See :data:`ptwt.constants.BoundaryMode`.
         level (int): The number of desired scales.
             Defaults to None.
         axes (Tuple[int, int]): Compute the transform over these axes instead of the

--- a/src/ptwt/conv_transform_2.py
+++ b/src/ptwt/conv_transform_2.py
@@ -149,7 +149,7 @@ def wavedec2(
         wavelet (Wavelet or str): A pywt wavelet compatible object or
             the name of a pywt wavelet. Refer to the output of
             ``pywt.wavelist(kind="discrete")`` for a list of possible choices.
-        mode (str): The padding mode. Options are::
+        mode : The padding mode. Options are::
 
                 "reflect", "zero", "constant", "periodic", "symmetric".
 

--- a/src/ptwt/conv_transform_2.py
+++ b/src/ptwt/conv_transform_2.py
@@ -131,7 +131,7 @@ def _preprocess_tensor_dec2d(
 def wavedec2(
     data: torch.Tensor,
     wavelet: Union[Wavelet, str],
-    mode: str = "reflect",
+    mode: BoundaryMode = "reflect",
     level: Optional[int] = None,
     axes: Tuple[int, int] = (-2, -1),
 ) -> List[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]]:

--- a/src/ptwt/conv_transform_3.py
+++ b/src/ptwt/conv_transform_3.py
@@ -64,7 +64,7 @@ def _construct_3d_filt(lo: torch.Tensor, hi: torch.Tensor) -> torch.Tensor:
 
 
 def _fwt_pad3(
-    data: torch.Tensor, wavelet: Union[Wavelet, str], mode: BoundaryMode
+    data: torch.Tensor, wavelet: Union[Wavelet, str], *, mode: BoundaryMode
 ) -> torch.Tensor:
     """Pad data for the 3d-FWT.
 

--- a/src/ptwt/conv_transform_3.py
+++ b/src/ptwt/conv_transform_3.py
@@ -74,9 +74,9 @@ def _fwt_pad3(
         data (torch.Tensor): Input data with 4 dimensions.
         wavelet (Wavelet or str): A pywt wavelet compatible object or
             the name of a pywt wavelet.
-        mode : The padding mode. Supported modes are::
-
-            "reflect", "zero", "constant", "periodic", "symmetric".
+        mode :
+            The desired padding mode for extending the signal along the edges.
+            See :data:`ptwt.constants.BoundaryMode`.
 
     Returns:
         The padded output tensor.
@@ -116,11 +116,9 @@ def wavedec3(
             [batch_size, length, height, width]
         wavelet (Union[Wavelet, str]): The wavelet to transform with.
             ``pywt.wavelist(kind='discrete')`` lists possible choices.
-        mode : The padding mode. Possible options are::
-
-                "reflect", "zero", "constant", "periodic", "symmetric".
-
-            Defaults to "zero".
+        mode :
+            The desired padding mode for extending the signal along the edges.
+            Defaults to "zero". See :data:`ptwt.constants.BoundaryMode`.
         level (Optional[int]): The maximum decomposition level.
             This argument defaults to None.
         axes (Tuple[int, int, int]): Compute the transform over these axes

--- a/src/ptwt/matmul_transform.py
+++ b/src/ptwt/matmul_transform.py
@@ -142,6 +142,9 @@ def orthogonalize(
 
     Returns:
         torch.Tensor: Orthogonal sparse transformation matrix.
+
+    Raises:
+        ValueError: If an invalid orthogonalization method is given
     """
     to_orthogonalize = _get_to_orthogonalize(matrix, filt_len)
     if len(to_orthogonalize) == 0:

--- a/src/ptwt/matmul_transform.py
+++ b/src/ptwt/matmul_transform.py
@@ -20,6 +20,7 @@ from ._util import (
     _is_dtype_supported,
     _unfold_axes,
 )
+from .constants import OrthogonalizeMethod
 from .conv_transform import (
     _get_filter_tensors,
     _postprocess_result_list_dec1d,
@@ -127,14 +128,14 @@ def _get_to_orthogonalize(matrix: torch.Tensor, filt_len: int) -> torch.Tensor:
 
 
 def orthogonalize(
-    matrix: torch.Tensor, filt_len: int, method: str = "qr"
+    matrix: torch.Tensor, filt_len: int, method: OrthogonalizeMethod = "qr"
 ) -> torch.Tensor:
     """Orthogonalization for sparse filter matrices.
 
     Args:
         matrix (torch.Tensor): The sparse filter matrix to orthogonalize.
         filt_len (int): The length of the wavelet filter coefficients.
-        method (str): The orthogonalization method to use. Choose qr
+        method : The orthogonalization method to use. Choose qr
             or gramschmidt. The dense qr code will run much faster
             than sparse gramschidt. Choose gramschmidt if qr fails.
             Defaults to qr.
@@ -143,13 +144,13 @@ def orthogonalize(
         torch.Tensor: Orthogonal sparse transformation matrix.
     """
     to_orthogonalize = _get_to_orthogonalize(matrix, filt_len)
-    if len(to_orthogonalize) > 0:
-        if method == "qr":
-            matrix = _orth_by_qr(matrix, to_orthogonalize)
-        else:
-            matrix = _orth_by_gram_schmidt(matrix, to_orthogonalize)
-
-    return matrix
+    if len(to_orthogonalize) == 0:
+        return matrix
+    if method == "qr":
+        return _orth_by_qr(matrix, to_orthogonalize)
+    elif method == "gramschmidt":
+        return _orth_by_gram_schmidt(matrix, to_orthogonalize)
+    raise ValueError(f"Invalid orthogonalization method: {method}")
 
 
 class MatrixWavedec(object):
@@ -177,7 +178,7 @@ class MatrixWavedec(object):
         wavelet: Union[Wavelet, str],
         level: Optional[int] = None,
         axis: Optional[int] = -1,
-        boundary: str = "qr",
+        boundary: OrthogonalizeMethod = "qr",
     ) -> None:
         """Create a matrix-fwt object.
 
@@ -189,7 +190,7 @@ class MatrixWavedec(object):
                 None.
             axis (int, optional): The axis we would like to transform.
                 Defaults to -1.
-            boundary (str): The method used for boundary filter treatment.
+            boundary : The method used for boundary filter treatment.
                 Choose 'qr' or 'gramschmidt'. 'qr' relies on pytorch's dense qr
                 implementation, it is fast but memory hungry. The 'gramschmidt'
                 option is sparse, memory efficient, and slow. Choose 'gramschmidt' if
@@ -390,7 +391,7 @@ def construct_boundary_a(
     wavelet: Union[Wavelet, str],
     length: int,
     device: Union[torch.device, str] = "cpu",
-    boundary: str = "qr",
+    boundary: OrthogonalizeMethod = "qr",
     dtype: torch.dtype = torch.float64,
 ) -> torch.Tensor:
     """Construct a boundary-wavelet filter 1d-analysis matrix.
@@ -399,7 +400,7 @@ def construct_boundary_a(
         wavelet (Wavelet or str): A pywt wavelet compatible object or
             the name of a pywt wavelet.
         length (int): The number of entries in the input signal.
-        boundary (str): A string indicating the desired boundary treatment.
+        boundary : A string indicating the desired boundary treatment.
             Possible options are qr and gramschmidt. Defaults to
             qr.
         device: Where to place the matrix. Choose cpu or cuda.
@@ -419,7 +420,7 @@ def construct_boundary_s(
     wavelet: Union[Wavelet, str],
     length: int,
     device: Union[torch.device, str] = "cpu",
-    boundary: str = "qr",
+    boundary: OrthogonalizeMethod = "qr",
     dtype: torch.dtype = torch.float64,
 ) -> torch.Tensor:
     """Construct a boundary-wavelet filter 1d-synthesis matarix.
@@ -430,7 +431,7 @@ def construct_boundary_s(
         length (int): The number of entries in the input signal.
         device (torch.device): Where to place the matrix.
             Choose cpu or cuda. Defaults to cpu.
-        boundary (str): A string indicating the desired boundary treatment.
+        boundary : A string indicating the desired boundary treatment.
             Possible options are qr and gramschmidt. Defaults to qr.
         dtype: Choose torch.float32 or torch.float64.
             Defaults to torch.float64.
@@ -462,7 +463,10 @@ class MatrixWaverec(object):
     """
 
     def __init__(
-        self, wavelet: Union[Wavelet, str], axis: int = -1, boundary: str = "qr"
+        self,
+        wavelet: Union[Wavelet, str],
+        axis: int = -1,
+        boundary: OrthogonalizeMethod = "qr",
     ) -> None:
         """Create the inverse matrix-based fast wavelet transformation.
 
@@ -471,7 +475,7 @@ class MatrixWaverec(object):
                 the name of a pywt wavelet.
             axis (int): The axis transformed by the original decomposition
                 defaults to -1 or the last axis.
-            boundary (str): The method used for boundary filter treatment.
+            boundary : The method used for boundary filter treatment.
                 Choose 'qr' or 'gramschmidt'. 'qr' relies on pytorch's dense qr
                 implementation, it is fast but memory hungry. The 'gramschmidt' option
                 is sparse, memory efficient, and slow. Choose 'gramschmidt' if 'qr' runs

--- a/src/ptwt/matmul_transform.py
+++ b/src/ptwt/matmul_transform.py
@@ -63,10 +63,10 @@ def _construct_a(
         wavelet, flip=False, device=device, dtype=dtype
     )
     analysis_lo = construct_strided_conv_matrix(
-        dec_lo.squeeze(), length, 2, "sameshift"
+        dec_lo.squeeze(), length, 2, mode="sameshift"
     )
     analysis_hi = construct_strided_conv_matrix(
-        dec_hi.squeeze(), length, 2, "sameshift"
+        dec_hi.squeeze(), length, 2, mode="sameshift"
     )
     analysis = torch.cat([analysis_lo, analysis_hi])
     return analysis
@@ -100,10 +100,10 @@ def _construct_s(
         wavelet, flip=True, device=device, dtype=dtype
     )
     synthesis_lo = construct_strided_conv_matrix(
-        rec_lo.squeeze(), length, 2, "sameshift"
+        rec_lo.squeeze(), length, 2, mode="sameshift"
     )
     synthesis_hi = construct_strided_conv_matrix(
-        rec_hi.squeeze(), length, 2, "sameshift"
+        rec_hi.squeeze(), length, 2, mode="sameshift"
     )
     synthesis = torch.cat([synthesis_lo, synthesis_hi])
     return synthesis.transpose(0, 1)

--- a/src/ptwt/matmul_transform_2.py
+++ b/src/ptwt/matmul_transform_2.py
@@ -22,7 +22,7 @@ from ._util import (
     _undo_swap_axes,
     _unfold_axes,
 )
-from .constants import Conv2DMode, OrthogonalizeMethod
+from .constants import OrthogonalizeMethod, PaddingMode
 from .conv_transform import _get_filter_tensors
 from .conv_transform_2 import (
     _construct_2d_filt,
@@ -43,7 +43,7 @@ def _construct_a_2(
     width: int,
     device: Union[torch.device, str],
     dtype: torch.dtype = torch.float64,
-    mode: Conv2DMode = "sameshift",
+    mode: PaddingMode = "sameshift",
 ) -> torch.Tensor:
     """Construct a raw two-dimensional analysis wavelet transformation matrix.
 
@@ -88,7 +88,7 @@ def _construct_s_2(
     width: int,
     device: Union[torch.device, str],
     dtype: torch.dtype = torch.float64,
-    mode: Conv2DMode = "sameshift",
+    mode: PaddingMode = "sameshift",
 ) -> torch.Tensor:
     """Construct a raw fast wavelet transformation synthesis matrix.
 

--- a/src/ptwt/matmul_transform_2.py
+++ b/src/ptwt/matmul_transform_2.py
@@ -22,6 +22,7 @@ from ._util import (
     _undo_swap_axes,
     _unfold_axes,
 )
+from .constants import Conv2DMode, OrthogonalizeMethod
 from .conv_transform import _get_filter_tensors
 from .conv_transform_2 import (
     _construct_2d_filt,
@@ -42,7 +43,7 @@ def _construct_a_2(
     width: int,
     device: Union[torch.device, str],
     dtype: torch.dtype = torch.float64,
-    mode: str = "sameshift",
+    mode: Conv2DMode = "sameshift",
 ) -> torch.Tensor:
     """Construct a raw two-dimensional analysis wavelet transformation matrix.
 
@@ -54,7 +55,7 @@ def _construct_a_2(
         device (torch.device or str): Where to place the matrix.
         dtype (torch.dtype, optional): Desired matrix data type.
             Defaults to torch.float64.
-        mode (str): The convolution type.
+        mode : The convolution type.
             Options are 'full', 'valid', 'same' and 'sameshift'.
             Defaults to 'sameshift'.
 
@@ -87,7 +88,7 @@ def _construct_s_2(
     width: int,
     device: Union[torch.device, str],
     dtype: torch.dtype = torch.float64,
-    mode: str = "sameshift",
+    mode: Conv2DMode = "sameshift",
 ) -> torch.Tensor:
     """Construct a raw fast wavelet transformation synthesis matrix.
 
@@ -106,7 +107,7 @@ def _construct_s_2(
             usually CPU or GPU.
         dtype (torch.dtype, optional): The data type the matrix should have.
             Defaults to torch.float64.
-        mode (str): The convolution type.
+        mode : The convolution type.
             Options are 'full', 'valid', 'same' and 'sameshift'.
             Defaults to 'sameshift'.
 
@@ -140,7 +141,7 @@ def construct_boundary_a2(
     height: int,
     width: int,
     device: Union[torch.device, str],
-    boundary: str = "qr",
+    boundary: OrthogonalizeMethod = "qr",
     dtype: torch.dtype = torch.float64,
 ) -> torch.Tensor:
     """Construct a boundary fwt matrix for the input wavelet.
@@ -154,7 +155,7 @@ def construct_boundary_a2(
             Should be divisible by two.
         device (torch.device): Where to place the matrix. Either on
             the CPU or GPU.
-        boundary (str): The method to use for matrix orthogonalization.
+        boundary : The method to use for matrix orthogonalization.
             Choose "qr" or "gramschmidt". Defaults to "qr".
         dtype (torch.dtype, optional): The desired data type for the matrix.
             Defaults to torch.float64.
@@ -174,7 +175,8 @@ def construct_boundary_s2(
     height: int,
     width: int,
     device: Union[torch.device, str],
-    boundary: str = "qr",
+    *,
+    boundary: OrthogonalizeMethod = "qr",
     dtype: torch.dtype = torch.float64,
 ) -> torch.Tensor:
     """Construct a 2d-fwt matrix, with boundary wavelets.
@@ -185,7 +187,7 @@ def construct_boundary_s2(
         height (int): The original height of the input matrix.
         width (int): The width of the original input matrix.
         device (torch.device): Choose CPU or GPU.
-        boundary (str): The method to use for matrix orthogonalization.
+        boundary : The method to use for matrix orthogonalization.
             Choose qr or gramschmidt. Defaults to qr.
         dtype (torch.dtype, optional): The data type of the
             sparse matrix, choose float32 or 64.
@@ -250,7 +252,7 @@ class MatrixWavedec2(object):
         wavelet: Union[Wavelet, str],
         level: Optional[int] = None,
         axes: Tuple[int, int] = (-2, -1),
-        boundary: str = "qr",
+        boundary: OrthogonalizeMethod = "qr",
         separable: bool = True,
     ):
         """Create a new matrix fwt object.
@@ -263,7 +265,7 @@ class MatrixWavedec2(object):
                 None.
             axes (int, int): A tuple with the axes to transform.
                 Defaults to (-2, -1).
-            boundary (str): The method used for boundary filter treatment.
+            boundary : The method used for boundary filter treatment.
                 Choose 'qr' or 'gramschmidt'. 'qr' relies on Pytorch's
                 dense qr implementation, it is fast but memory hungry.
                 The 'gramschmidt' option is sparse, memory efficient,
@@ -569,7 +571,7 @@ class MatrixWaverec2(object):
         self,
         wavelet: Union[Wavelet, str],
         axes: Tuple[int, int] = (-2, -1),
-        boundary: str = "qr",
+        boundary: OrthogonalizeMethod = "qr",
         separable: bool = True,
     ):
         """Create the inverse matrix-based fast wavelet transformation.
@@ -579,7 +581,7 @@ class MatrixWaverec2(object):
                 the name of a pywt wavelet.
             axes (int, int): The axes transformed by waverec2.
                 Defaults to (-2, -1).
-            boundary (str): The method used for boundary filter treatment.
+            boundary : The method used for boundary filter treatment.
                 Choose 'qr' or 'gramschmidt'. 'qr' relies on pytorch's dense qr
                 implementation, it is fast but memory hungry. The 'gramschmidt' option
                 is sparse, memory efficient, and slow. Choose 'gramschmidt' if 'qr' runs

--- a/src/ptwt/matmul_transform_3.py
+++ b/src/ptwt/matmul_transform_3.py
@@ -19,6 +19,7 @@ from ._util import (
     _undo_swap_axes,
     _unfold_axes,
 )
+from .constants import OrthogonalizeMethod
 from .conv_transform_3 import _waverec3d_fold_channels_3d_list
 from .matmul_transform import construct_boundary_a, construct_boundary_s
 from .sparse_math import _batch_dim_mm
@@ -276,7 +277,7 @@ class MatrixWaverec3(object):
         self,
         wavelet: Union[Wavelet, str],
         axes: Tuple[int, int, int] = (-3, -2, -1),
-        boundary: str = "qr",
+        boundary: OrthogonalizeMethod = "qr",
     ):
         """Compute a three-dimensional separable boundary wavelet synthesis transform.
 
@@ -285,7 +286,7 @@ class MatrixWaverec3(object):
                 the name of a pywt wavelet.
             axes (Tuple[int, int, int]): Transform these axes instead of the
                 last three. Defaults to (-3, -2, -1).
-            boundary (str): The method used for boundary filter treatment.
+            boundary : The method used for boundary filter treatment.
                 Choose 'qr' or 'gramschmidt'. 'qr' relies on Pytorch's dense qr
                 implementation, it is fast but memory hungry. The 'gramschmidt' option
                 is sparse, memory efficient, and slow. Choose 'gramschmidt' if 'qr' runs

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -11,6 +11,7 @@ import pywt
 import torch
 
 from ._util import Wavelet, _as_wavelet
+from .constants import BoundaryMode, OrthogonalizeMethod
 from .conv_transform import wavedec, waverec
 from .conv_transform_2 import wavedec2, waverec2
 from .matmul_transform import MatrixWavedec, MatrixWaverec
@@ -48,10 +49,10 @@ class WaveletPacket(BaseDict):
         self,
         data: Optional[torch.Tensor],
         wavelet: Union[Wavelet, str],
-        mode: Optional[str] = "reflect",
+        mode: Optional[BoundaryMode] = "reflect",
         maxlevel: Optional[int] = None,
         axis: int = -1,
-        boundary_orthogonalization: str = "qr",
+        boundary_orthogonalization: OrthogonalizeMethod = "qr",
     ) -> None:
         """Create a wavelet packet decomposition object.
 
@@ -66,13 +67,13 @@ class WaveletPacket(BaseDict):
                 Use the ``axis`` argument to choose another dimension.
             wavelet (Wavelet or str): A pywt wavelet compatible object or
                 the name of a pywt wavelet.
-            mode (str, optional): The desired padding method. If you select 'boundary',
+            mode : The desired padding method. If you select 'boundary',
                 the sparse matrix backend will be used. Defaults to 'reflect'.
             maxlevel (int, optional): Value is passed on to `transform`.
                 The highest decomposition level to compute. If None, the maximum level
                 is determined from the input data shape. Defaults to None.
             axis (int): The axis to transform. Defaults to -1.
-            boundary_orthogonalization (str): The orthogonalization method
+            boundary_orthogonalization : The orthogonalization method
                 to use. Only used if `mode` equals 'boundary'. Choose from
                 'qr' or 'gramschmidt'. Defaults to 'qr'.
 
@@ -263,10 +264,10 @@ class WaveletPacket2D(BaseDict):
         self,
         data: Optional[torch.Tensor],
         wavelet: Union[Wavelet, str],
-        mode: str = "reflect",
+        mode: BoundaryMode = "reflect",
         maxlevel: Optional[int] = None,
         axes: Tuple[int, int] = (-2, -1),
-        boundary_orthogonalization: str = "qr",
+        boundary_orthogonalization: OrthogonalizeMethod = "qr",
         separable: bool = False,
     ) -> None:
         """Create a 2D-Wavelet packet tree.
@@ -279,7 +280,7 @@ class WaveletPacket2D(BaseDict):
                 a decomposition.
             wavelet (Wavelet or str): A pywt wavelet compatible object or
                 the name of a pywt wavelet.
-            mode (str): A string indicating the desired padding mode.
+            mode : A string indicating the desired padding mode.
                 If you select 'boundary', the sparse matrix backend is used.
                 Defaults to 'reflect'
             maxlevel (int, optional): Value is passed on to `transform`.
@@ -287,7 +288,7 @@ class WaveletPacket2D(BaseDict):
                 is determined from the input data shape. Defaults to None.
             axes ([int, int], optional): The tensor axes that should be transformed.
                 Defaults to (-2, -1).
-            boundary_orthogonalization (str): The orthogonalization method
+            boundary_orthogonalization : The orthogonalization method
                 to use in the sparse matrix backend. Only used if `mode`
                 equals 'boundary'. Choose from 'qr' or 'gramschmidt'.
                 Defaults to 'qr'.

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -4,25 +4,15 @@
 import collections
 from functools import partial
 from itertools import product
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union, cast
 
 import numpy as np
 import pywt
 import torch
 
 from ._util import Wavelet, _as_wavelet
-from .constants import BoundaryMode, ExtendedBoundaryMode, OrthogonalizeMethod
-from .conv_transform import _translate_boundary_strings, wavedec, waverec
+from .constants import ExtendedBoundaryMode, OrthogonalizeMethod
+from .conv_transform import wavedec, waverec
 from .conv_transform_2 import wavedec2, waverec2
 from .matmul_transform import MatrixWavedec, MatrixWaverec
 from .matmul_transform_2 import MatrixWavedec2, MatrixWaverec2

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -4,15 +4,25 @@
 import collections
 from functools import partial
 from itertools import product
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 import numpy as np
 import pywt
 import torch
 
 from ._util import Wavelet, _as_wavelet
-from .constants import BoundaryMode, OrthogonalizeMethod
-from .conv_transform import wavedec, waverec
+from .constants import BoundaryMode, ExtendedBoundaryMode, OrthogonalizeMethod
+from .conv_transform import _translate_boundary_strings, wavedec, waverec
 from .conv_transform_2 import wavedec2, waverec2
 from .matmul_transform import MatrixWavedec, MatrixWaverec
 from .matmul_transform_2 import MatrixWavedec2, MatrixWaverec2
@@ -49,7 +59,7 @@ class WaveletPacket(BaseDict):
         self,
         data: Optional[torch.Tensor],
         wavelet: Union[Wavelet, str],
-        mode: Optional[BoundaryMode] = "reflect",
+        mode: ExtendedBoundaryMode = "reflect",
         maxlevel: Optional[int] = None,
         axis: int = -1,
         boundary_orthogonalization: OrthogonalizeMethod = "qr",
@@ -264,7 +274,7 @@ class WaveletPacket2D(BaseDict):
         self,
         data: Optional[torch.Tensor],
         wavelet: Union[Wavelet, str],
-        mode: BoundaryMode = "reflect",
+        mode: ExtendedBoundaryMode = "reflect",
         maxlevel: Optional[int] = None,
         axes: Tuple[int, int] = (-2, -1),
         boundary_orthogonalization: OrthogonalizeMethod = "qr",

--- a/src/ptwt/separable_conv_transform.py
+++ b/src/ptwt/separable_conv_transform.py
@@ -106,7 +106,7 @@ def _separable_conv_idwtn(
 def _separable_conv_wavedecn(
     input: torch.Tensor,
     wavelet: pywt.Wavelet,
-    mode: str = "reflect",
+    mode: BoundaryMode = "reflect",
     level: Optional[int] = None,
 ) -> List[Union[torch.Tensor, Dict[str, torch.Tensor]]]:
     """Compute a multilevel separable padded wavelet analysis transform.
@@ -131,7 +131,7 @@ def _separable_conv_wavedecn(
 
     for _ in range(level):
         level_dict: Dict[str, torch.Tensor] = {}
-        _separable_conv_dwtn_(level_dict, approx, wavelet, mode, "")
+        _separable_conv_dwtn_(level_dict, approx, wavelet, mode=mode, key="")
         approx_key = "a" * (len(input.shape) - 1)
         approx = level_dict.pop(approx_key)
         result.append(level_dict)
@@ -173,7 +173,7 @@ def _separable_conv_waverecn(
 def fswavedec2(
     data: torch.Tensor,
     wavelet: Union[str, pywt.Wavelet],
-    mode: str = "reflect",
+    mode: BoundaryMode = "reflect",
     level: Optional[int] = None,
     axes: Tuple[int, int] = (-2, -1),
 ) -> List[Union[torch.Tensor, Dict[str, torch.Tensor]]]:
@@ -244,7 +244,7 @@ def fswavedec2(
 def fswavedec3(
     data: torch.Tensor,
     wavelet: Union[str, pywt.Wavelet],
-    mode: str = "reflect",
+    mode: BoundaryMode = "reflect",
     level: Optional[int] = None,
     axes: Tuple[int, int, int] = (-3, -2, -1),
 ) -> List[Union[torch.Tensor, Dict[str, torch.Tensor]]]:

--- a/src/ptwt/separable_conv_transform.py
+++ b/src/ptwt/separable_conv_transform.py
@@ -33,6 +33,7 @@ def _separable_conv_dwtn_(
     rec_dict: Dict[str, torch.Tensor],
     input_arg: torch.Tensor,
     wavelet: Union[str, pywt.Wavelet],
+    *,
     mode: BoundaryMode = "reflect",
     key: str = "",
 ) -> None:
@@ -106,6 +107,7 @@ def _separable_conv_idwtn(
 def _separable_conv_wavedecn(
     input: torch.Tensor,
     wavelet: pywt.Wavelet,
+    *,
     mode: BoundaryMode = "reflect",
     level: Optional[int] = None,
 ) -> List[Union[torch.Tensor, Dict[str, torch.Tensor]]]:
@@ -173,6 +175,7 @@ def _separable_conv_waverecn(
 def fswavedec2(
     data: torch.Tensor,
     wavelet: Union[str, pywt.Wavelet],
+    *,
     mode: BoundaryMode = "reflect",
     level: Optional[int] = None,
     axes: Tuple[int, int] = (-2, -1),
@@ -244,6 +247,7 @@ def fswavedec2(
 def fswavedec3(
     data: torch.Tensor,
     wavelet: Union[str, pywt.Wavelet],
+    *,
     mode: BoundaryMode = "reflect",
     level: Optional[int] = None,
     axes: Tuple[int, int, int] = (-3, -2, -1),

--- a/src/ptwt/separable_conv_transform.py
+++ b/src/ptwt/separable_conv_transform.py
@@ -61,8 +61,8 @@ def _separable_conv_dwtn_(
         res_a, res_d = wavedec(
             input_arg, wavelet, level=1, mode=mode, axis=-current_axis
         )
-        _separable_conv_dwtn_(rec_dict, res_a, wavelet, mode, "a" + key)
-        _separable_conv_dwtn_(rec_dict, res_d, wavelet, mode, "d" + key)
+        _separable_conv_dwtn_(rec_dict, res_a, wavelet, mode=mode, key="a" + key)
+        _separable_conv_dwtn_(rec_dict, res_d, wavelet, mode=mode, key="d" + key)
 
 
 def _separable_conv_idwtn(
@@ -231,7 +231,7 @@ def fswavedec2(
     wavelet = _as_wavelet(wavelet)
     data, ds = _preprocess_tensor_dec2d(data)
     data = data.squeeze(1)
-    res = _separable_conv_wavedecn(data, wavelet, mode, level)
+    res = _separable_conv_wavedecn(data, wavelet, mode=mode, level=level)
 
     if ds:
         _unfold_axes2 = partial(_unfold_axes, ds=ds, keep_no=2)

--- a/src/ptwt/separable_conv_transform.py
+++ b/src/ptwt/separable_conv_transform.py
@@ -24,6 +24,7 @@ from ._util import (
     _undo_swap_axes,
     _unfold_axes,
 )
+from .constants import BoundaryMode
 from .conv_transform import wavedec, waverec
 from .conv_transform_2 import _preprocess_tensor_dec2d
 
@@ -32,7 +33,7 @@ def _separable_conv_dwtn_(
     rec_dict: Dict[str, torch.Tensor],
     input_arg: torch.Tensor,
     wavelet: Union[str, pywt.Wavelet],
-    mode: str = "reflect",
+    mode: BoundaryMode = "reflect",
     key: str = "",
 ) -> None:
     """Compute a single-level separable fast wavelet transform.
@@ -42,7 +43,7 @@ def _separable_conv_dwtn_(
     Args:
         input_arg (torch.Tensor): Tensor of shape [batch, data_1, ... data_n].
         wavelet (Union[str, pywt.Wavelet]): The Wavelet to work with.
-        mode (str): The padding mode. The following methods are supported::
+        mode : The padding mode. The following methods are supported::
 
                 "reflect", "zero", "constant", "periodic".
 

--- a/src/ptwt/separable_conv_transform.py
+++ b/src/ptwt/separable_conv_transform.py
@@ -114,7 +114,7 @@ def _separable_conv_wavedecn(
     Args:
         input (torch.Tensor): A tensor i.e. of shape [batch,axis_1, ... axis_n].
         wavelet (Wavelet): A pywt wavelet compatible object.
-        mode (str): The desired padding mode.
+        mode : The desired padding mode.
         level (int): The desired decomposition level.
 
     Returns:
@@ -185,7 +185,7 @@ def fswavedec2(
         wavelet (Wavelet or str): A pywt wavelet compatible object or
             the name of a pywt wavelet. Refer to the output of
             ``pywt.wavelist(kind="discrete")`` for a list of possible choices.
-        mode (str): The padding mode. Options are::
+        mode : The padding mode. Options are::
 
                 "reflect", "zero", "constant", "periodic".
 
@@ -255,7 +255,7 @@ def fswavedec3(
         wavelet (Wavelet or str): A pywt wavelet compatible object or
             the name of a pywt wavelet. Refer to the output of
             ``pywt.wavelist(kind="discrete")`` for a list of possible choices.
-        mode (str): The padding mode. Options are::
+        mode : The padding mode. Options are::
 
                 "reflect", "zero", "constant", "periodic".
 

--- a/src/ptwt/separable_conv_transform.py
+++ b/src/ptwt/separable_conv_transform.py
@@ -188,11 +188,9 @@ def fswavedec2(
         wavelet (Wavelet or str): A pywt wavelet compatible object or
             the name of a pywt wavelet. Refer to the output of
             ``pywt.wavelist(kind="discrete")`` for a list of possible choices.
-        mode : The padding mode. Options are::
-
-                "reflect", "zero", "constant", "periodic".
-
-            This function defaults to "reflect".
+        mode :
+            The desired padding mode for extending the signal along the edges.
+            Defaults to "reflect". See :data:`ptwt.constants.BoundaryMode`.
         level (int): The number of desired scales.
             Defaults to None.
         axes ([int, int]): The axes we want to transform,
@@ -259,11 +257,9 @@ def fswavedec3(
         wavelet (Wavelet or str): A pywt wavelet compatible object or
             the name of a pywt wavelet. Refer to the output of
             ``pywt.wavelist(kind="discrete")`` for a list of possible choices.
-        mode : The padding mode. Options are::
-
-                "reflect", "zero", "constant", "periodic".
-
-            This function defaults to "reflect".
+        mode :
+            The desired padding mode for extending the signal along the edges.
+            Defaults to "reflect". See :data:`ptwt.constants.BoundaryMode`.
         level (int): The number of desired scales.
             Defaults to None.
         axes (Tuple[int, int, int]): Compute the transform over these axes

--- a/src/ptwt/separable_conv_transform.py
+++ b/src/ptwt/separable_conv_transform.py
@@ -304,7 +304,7 @@ def fswavedec3(
     elif len(data.shape) < 4:
         raise ValueError("At lest four input dimensions are required.")
     data = data.squeeze(1)
-    res = _separable_conv_wavedecn(data, wavelet, mode, level)
+    res = _separable_conv_wavedecn(data, wavelet, mode=mode, level=level)
 
     if ds:
         _unfold_axes3 = partial(_unfold_axes, ds=ds, keep_no=3)

--- a/src/ptwt/sparse_math.py
+++ b/src/ptwt/sparse_math.py
@@ -5,7 +5,7 @@ from typing import List
 
 import torch
 
-from ptwt.constants import Conv2DMode
+from ptwt.constants import PaddingMode
 
 
 def _dense_kron(
@@ -331,7 +331,7 @@ def _orth_by_gram_schmidt(
 
 
 def construct_conv_matrix(
-    filter: torch.Tensor, input_rows: int, *, mode: Conv2DMode = "valid"
+    filter: torch.Tensor, input_rows: int, *, mode: PaddingMode = "valid"
 ) -> torch.Tensor:
     """Construct a convolution matrix.
 
@@ -392,7 +392,7 @@ def construct_conv2d_matrix(
     filter: torch.Tensor,
     input_rows: int,
     input_columns: int,
-    mode: Conv2DMode = "valid",
+    mode: PaddingMode = "valid",
     fully_sparse: bool = True,
 ) -> torch.Tensor:
     """Create a two-dimensional sparse convolution matrix.
@@ -464,7 +464,7 @@ def construct_strided_conv_matrix(
     input_rows: int,
     stride: int = 2,
     *,
-    mode: Conv2DMode = "valid"
+    mode: PaddingMode = "valid"
 ) -> torch.Tensor:
     """Construct a strided convolution matrix.
 
@@ -501,7 +501,7 @@ def construct_strided_conv2d_matrix(
     input_rows: int,
     input_columns: int,
     stride: int = 2,
-    mode: Conv2DMode = "full",
+    mode: PaddingMode = "full",
 ) -> torch.Tensor:
     """Create a strided sparse two-dimensional convolution matrix.
 

--- a/src/ptwt/sparse_math.py
+++ b/src/ptwt/sparse_math.py
@@ -5,6 +5,8 @@ from typing import List
 
 import torch
 
+from ptwt.constants import Conv2DMode
+
 
 def _dense_kron(
     sparse_tensor_a: torch.Tensor, sparse_tensor_b: torch.Tensor
@@ -329,7 +331,7 @@ def _orth_by_gram_schmidt(
 
 
 def construct_conv_matrix(
-    filter: torch.Tensor, input_rows: int, mode: str = "valid"
+    filter: torch.Tensor, input_rows: int, *, mode: Conv2DMode = "valid"
 ) -> torch.Tensor:
     """Construct a convolution matrix.
 
@@ -341,7 +343,7 @@ def construct_conv_matrix(
     Args:
         filter (torch.tensor): The 1D-filter to convolve with.
         input_rows (int): The number of columns in the input.
-        mode (str): String identifier for the desired padding.
+        mode : String identifier for the desired padding.
             Choose 'full', 'valid' or 'same'.
             Defaults to valid.
 
@@ -390,10 +392,10 @@ def construct_conv2d_matrix(
     filter: torch.Tensor,
     input_rows: int,
     input_columns: int,
-    mode: str = "valid",
+    mode: Conv2DMode = "valid",
     fully_sparse: bool = True,
 ) -> torch.Tensor:
-    """Create a two dimensional sparse convolution matrix.
+    """Create a two-dimensional sparse convolution matrix.
 
     Convolving with this matrix should be equivalent to
     a call to scipy.signal.convolve2d and a reshape.
@@ -437,7 +439,9 @@ def construct_conv2d_matrix(
 
     block_matrix_list = []
     for i in range(matrix_block_number):
-        block_matrix_list.append(construct_conv_matrix(filter[:, i], input_rows, mode))
+        block_matrix_list.append(
+            construct_conv_matrix(filter[:, i], input_rows, mode=mode)
+        )
 
     diag_values = torch.ones(
         min(kronecker_rows, input_columns),
@@ -456,7 +460,11 @@ def construct_conv2d_matrix(
 
 
 def construct_strided_conv_matrix(
-    filter: torch.Tensor, input_rows: int, stride: int = 2, mode: str = "valid"
+    filter: torch.Tensor,
+    input_rows: int,
+    *,
+    stride: int = 2,
+    mode: Conv2DMode = "valid"
 ) -> torch.Tensor:
     """Construct a strided convolution matrix.
 
@@ -465,7 +473,7 @@ def construct_strided_conv_matrix(
         input_rows (int): The number of rows in the input vector.
         stride (int): The step size of the convolution.
             Defaults to two.
-        mode (str): Choose 'valid', 'same' or 'sameshift'.
+        mode : Choose 'valid', 'same' or 'sameshift'.
             Defaults to 'valid'.
 
     Returns:
@@ -493,9 +501,9 @@ def construct_strided_conv2d_matrix(
     input_rows: int,
     input_columns: int,
     stride: int = 2,
-    mode: str = "full",
+    mode: Conv2DMode = "full",
 ) -> torch.Tensor:
-    """Create a strided sparse two dimensional convolution matrix.
+    """Create a strided sparse two-dimensional convolution matrix.
 
     Args:
         filter (torch.Tensor): The two-dimensional convolution filter.
@@ -503,8 +511,7 @@ def construct_strided_conv2d_matrix(
         input_columns (int): The number of columns in the 2d- input matrix.
         stride (int): The stride between the filter positions.
             Defaults to 2.
-        mode (str): The convolution type.
-            Options are 'full', 'valid', 'same' and 'sameshift'.
+        mode : The convolution type.
             Defaults to 'full'. Sameshift starts at 1 instead of 0.
 
     Raises:

--- a/src/ptwt/sparse_math.py
+++ b/src/ptwt/sparse_math.py
@@ -462,8 +462,8 @@ def construct_conv2d_matrix(
 def construct_strided_conv_matrix(
     filter: torch.Tensor,
     input_rows: int,
-    *,
     stride: int = 2,
+    *,
     mode: Conv2DMode = "valid"
 ) -> torch.Tensor:
     """Construct a strided convolution matrix.

--- a/src/ptwt/sparse_math.py
+++ b/src/ptwt/sparse_math.py
@@ -479,7 +479,7 @@ def construct_strided_conv_matrix(
     Returns:
         torch.Tensor: The strided sparse convolution matrix.
     """
-    conv_matrix = construct_conv_matrix(filter, input_rows, mode)
+    conv_matrix = construct_conv_matrix(filter, input_rows, mode=mode)
     if mode == "sameshift":
         # find conv_matrix[1:stride, :] sparsely
         select_rows = torch.arange(1, conv_matrix.shape[0], stride)

--- a/tests/test_convolution_fwt.py
+++ b/tests/test_convolution_fwt.py
@@ -283,7 +283,7 @@ def test_input_1d_dimension_error():
     """Test the error for 1d inputs to wavedec2."""
     with pytest.raises(ValueError):
         data = torch.randn(50)
-        wavedec2(data, "haar", 4)
+        wavedec2(data, "haar", level=4)
 
 
 def _compare_coeffs(ptwt_res, pywt_res):

--- a/tests/test_convolution_fwt.py
+++ b/tests/test_convolution_fwt.py
@@ -358,11 +358,11 @@ def test_2d_axis_error_axes_count():
     """Check the error for too many axes."""
     with pytest.raises(ValueError):
         data = torch.randn([32, 32, 32, 32], dtype=torch.float64)
-        wavedec2(data, "haar", 1, axes=(1, 2, 3))
+        wavedec2(data, "haar", level=1, axes=(1, 2, 3))
 
 
 def test_2d_axis_error_axes_repetition():
     """Check the error for axes repetition."""
     with pytest.raises(ValueError):
         data = torch.randn([32, 32, 32, 32], dtype=torch.float64)
-        wavedec2(data, "haar", 1, axes=(2, 2))
+        wavedec2(data, "haar", level=1, axes=(2, 2))

--- a/tests/test_convolution_fwt_3.py
+++ b/tests/test_convolution_fwt_3.py
@@ -8,8 +8,8 @@ import pytest
 import pywt
 import torch
 
-from ptwt.constants import BoundaryMode
 import ptwt
+from ptwt.constants import BoundaryMode
 
 
 def _expand_dims(batch_list: List) -> List:

--- a/tests/test_convolution_fwt_3.py
+++ b/tests/test_convolution_fwt_3.py
@@ -1,5 +1,6 @@
 """Test our 3d for loop-convolution based fwt code."""
 
+import typing
 from typing import List
 
 import numpy as np
@@ -8,6 +9,7 @@ import pywt
 import torch
 
 import src.ptwt as ptwt
+from ptwt.constants import BoundaryMode
 
 
 def _expand_dims(batch_list: List) -> List:

--- a/tests/test_convolution_fwt_3.py
+++ b/tests/test_convolution_fwt_3.py
@@ -54,10 +54,8 @@ def _cat_batch_list(batch_lists: List) -> List:
 )
 @pytest.mark.parametrize("wavelet", ["haar", "db2", "db4"])
 @pytest.mark.parametrize("level", [1, 2, None])
-@pytest.mark.parametrize(
-    "mode", ["reflect", "zero", "constant", "periodic", "symmetric"]
-)
-def test_waverec3(shape: list, wavelet: str, level: int, mode: str) -> None:
+@pytest.mark.parametrize("mode", typing.get_args(BoundaryMode))
+def test_waverec3(shape: list, wavelet: str, level: int, mode: BoundaryMode) -> None:
     """Ensure the 3d analysis transform is invertible."""
     data = np.random.randn(*shape)
     data = torch.from_numpy(data)
@@ -120,10 +118,12 @@ def test_multidim_input(size: List[int], level: int, wavelet: str, mode: str):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("axes", [[-3, -2, -1], [0, 2, 1]])
+@pytest.mark.parametrize("axes", [(-3, -2, -1), (0, 2, 1)])
 @pytest.mark.parametrize("level", [1, 2, None])
 @pytest.mark.parametrize("mode", ["zero", "symmetric", "reflect"])
-def test_axes_arg_3d(axes: List[int], level: int, mode: str) -> None:
+def test_axes_arg_3d(
+    axes: tuple[int, int, int], level: int, mode: BoundaryMode
+) -> None:
     """Test axes argument support."""
     wavelet = "db3"
     data = torch.randn([16, 16, 16, 16, 16], dtype=torch.float64)

--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -69,7 +69,7 @@ def _to_jit_wavedec_2(data, wavelet):
     means we have to stack the lists in the output.
     """
     assert data.shape == (10, 20, 20), "Changing the chape requires re-tracing."
-    coeff = ptwt.wavedec2(data, wavelet, "reflect", 2)
+    coeff = ptwt.wavedec2(data, wavelet, mode="reflect", level=2)
     coeff2 = []
     for c in coeff:
         if isinstance(c, torch.Tensor):

--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -116,8 +116,8 @@ def _to_jit_wavedec_3(data, wavelet):
     Going from List[Union[torch.Tensor, Dict[str, torch.Tensor]]] to List[torch.Tensor]
     means we have to stack the lists in the output.
     """
-    assert data.shape == (10, 20, 20, 20), "Changing the chape requires re-tracing."
-    coeff = ptwt.wavedec3(data, wavelet, "reflect", 2)
+    assert data.shape == (10, 20, 20, 20), "Changing the shape requires re-tracing."
+    coeff = ptwt.wavedec3(data, wavelet, mode="reflect", level=2)
     coeff2 = []
     keys = ("aad", "ada", "add", "daa", "dad", "dda", "ddd")
     for c in coeff:

--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -31,7 +31,7 @@ def _set_up_wavelet_tuple(wavelet, dtype):
 
 
 def _to_jit_wavedec_fun(data, wavelet, level):
-    return ptwt.wavedec(data, wavelet, "reflect", level)
+    return ptwt.wavedec(data, wavelet, mode="reflect", level=level)
 
 
 @pytest.mark.slow

--- a/tests/test_separable_conv_fwt.py
+++ b/tests/test_separable_conv_fwt.py
@@ -118,7 +118,7 @@ def test_conv_mm_3d(level, axes, shape):
     """Compare mm and conv 3d fully separable results."""
     data = torch.randn(*shape).type(torch.float64)
     fs_conv_coeff = fswavedec3(data, "haar", level=level, axes=axes)
-    fs_mm_coeff = MatrixWavedec3("haar", level, axes=axes)(data)
+    fs_mm_coeff = MatrixWavedec3("haar", level=level, axes=axes)(data)
     # compare coefficients
     assert len(fs_conv_coeff) == len(fs_mm_coeff)
     for c_conv, c_mm in zip(fs_conv_coeff, fs_mm_coeff):

--- a/tests/test_sparse_math.py
+++ b/tests/test_sparse_math.py
@@ -6,7 +6,7 @@ import scipy.signal
 import torch
 from scipy import datasets
 
-from ptwt.constants import Conv2DMode
+from ptwt.constants import PaddingMode
 from src.ptwt.sparse_math import (
     batch_mm,
     construct_conv2d_matrix,
@@ -39,7 +39,7 @@ def test_kron() -> None:
 @pytest.mark.parametrize("input_signal", [torch.rand([8]), torch.rand([9])])
 @pytest.mark.parametrize("padding", ["full", "same", "valid"])
 def test_conv_matrix(
-    test_filter: torch.Tensor, input_signal: torch.Tensor, padding: Conv2DMode
+    test_filter: torch.Tensor, input_signal: torch.Tensor, padding: PaddingMode
 ) -> None:
     """Test the 1d sparse convolution matrix code."""
     conv_matrix = construct_conv_matrix(test_filter, len(input_signal), mode=padding)
@@ -68,7 +68,7 @@ def test_conv_matrix(
     ],
 )
 @pytest.mark.parametrize("mode", ["valid", "same"])
-def test_strided_conv_matrix(test_filter, input_signal, mode: Conv2DMode) -> None:
+def test_strided_conv_matrix(test_filter, input_signal, mode: PaddingMode) -> None:
     """Test the strided 1d sparse convolution matrix code."""
     strided_conv_matrix = construct_strided_conv_matrix(
         test_filter, len(input_signal), 2, mode=mode
@@ -124,7 +124,7 @@ def test_strided_conv_matrix(test_filter, input_signal, mode: Conv2DMode) -> Non
 )
 @pytest.mark.parametrize("mode", ["same", "full", "valid"])
 @pytest.mark.parametrize("fully_sparse", [True, False])
-def test_conv_matrix_2d(filter_shape, size, mode: Conv2DMode, fully_sparse) -> None:
+def test_conv_matrix_2d(filter_shape, size, mode: PaddingMode, fully_sparse) -> None:
     """Test the validity of the 2d convolution matrix code.
 
     It should be equivalent to signal convolve2d.
@@ -163,7 +163,7 @@ def test_conv_matrix_2d(filter_shape, size, mode: Conv2DMode, fully_sparse) -> N
     ],
 )
 @pytest.mark.parametrize("mode", ["full", "valid"])
-def test_strided_conv_matrix_2d(filter_shape, size, mode: Conv2DMode) -> None:
+def test_strided_conv_matrix_2d(filter_shape, size, mode: PaddingMode) -> None:
     """Test strided convolution matrices with full and valid padding."""
     test_filter = torch.rand(filter_shape)
     test_filter = test_filter.unsqueeze(0).unsqueeze(0)

--- a/tests/test_sparse_math.py
+++ b/tests/test_sparse_math.py
@@ -6,6 +6,7 @@ import scipy.signal
 import torch
 from scipy import datasets
 
+from ptwt.constants import Conv2DMode
 from src.ptwt.sparse_math import (
     batch_mm,
     construct_conv2d_matrix,
@@ -38,10 +39,10 @@ def test_kron() -> None:
 @pytest.mark.parametrize("input_signal", [torch.rand([8]), torch.rand([9])])
 @pytest.mark.parametrize("padding", ["full", "same", "valid"])
 def test_conv_matrix(
-    test_filter: torch.Tensor, input_signal: torch.Tensor, padding: str
+    test_filter: torch.Tensor, input_signal: torch.Tensor, padding: Conv2DMode
 ) -> None:
     """Test the 1d sparse convolution matrix code."""
-    conv_matrix = construct_conv_matrix(test_filter, len(input_signal), padding)
+    conv_matrix = construct_conv_matrix(test_filter, len(input_signal), mode=padding)
     mm_conv_res = torch.sparse.mm(conv_matrix, input_signal.unsqueeze(-1)).squeeze()
     conv_res = scipy.signal.convolve(input_signal.numpy(), test_filter.numpy(), padding)
     error = np.sum(np.abs(conv_res - mm_conv_res.numpy()))

--- a/tests/test_sparse_math.py
+++ b/tests/test_sparse_math.py
@@ -68,10 +68,10 @@ def test_conv_matrix(
     ],
 )
 @pytest.mark.parametrize("mode", ["valid", "same"])
-def test_strided_conv_matrix(test_filter, input_signal, mode) -> None:
+def test_strided_conv_matrix(test_filter, input_signal, mode: Conv2DMode) -> None:
     """Test the strided 1d sparse convolution matrix code."""
     strided_conv_matrix = construct_strided_conv_matrix(
-        test_filter, len(input_signal), 2, mode
+        test_filter, len(input_signal), 2, mode=mode
     )
     mm_conv_res = torch.sparse.mm(
         strided_conv_matrix, input_signal.unsqueeze(-1)
@@ -124,7 +124,7 @@ def test_strided_conv_matrix(test_filter, input_signal, mode) -> None:
 )
 @pytest.mark.parametrize("mode", ["same", "full", "valid"])
 @pytest.mark.parametrize("fully_sparse", [True, False])
-def test_conv_matrix_2d(filter_shape, size, mode, fully_sparse) -> None:
+def test_conv_matrix_2d(filter_shape, size, mode: Conv2DMode, fully_sparse) -> None:
     """Test the validity of the 2d convolution matrix code.
 
     It should be equivalent to signal convolve2d.
@@ -163,7 +163,7 @@ def test_conv_matrix_2d(filter_shape, size, mode, fully_sparse) -> None:
     ],
 )
 @pytest.mark.parametrize("mode", ["full", "valid"])
-def test_strided_conv_matrix_2d(filter_shape, size, mode) -> None:
+def test_strided_conv_matrix_2d(filter_shape, size, mode: Conv2DMode) -> None:
     """Test strided convolution matrices with full and valid padding."""
     test_filter = torch.rand(filter_shape)
     test_filter = test_filter.unsqueeze(0).unsqueeze(0)


### PR DESCRIPTION
This PR does the following:

1. Creates a `Literal` type annotation for ptwt boundary modes
2. Uses this literal for type annotations. This has the benefit that it makes the type checker much smarter and also auto-generates docs
3. Re-write the docs for `mode` in many places to point to a centralized place where we can expand on padding.
4. Sets a lot of these parameters to be keyword-only. This will make code _much_ more understandable in the future, and also allows for easier development/debugging

Did the same thing for convolutional boundaries as well as orthogonalization method.
