### PR TITLE
SWT: Make circular padding wrap more than once if needed

### DIFF
--- a/tests/test_swt.py
+++ b/tests/test_swt.py
@@ -11,8 +11,8 @@ from ptwt._stationary_transform import _iswt, _swt
 
 
 @pytest.mark.parametrize("level", [1, 2, None])
-@pytest.mark.parametrize("size", [[1, 32], [3, 64], [5, 64]])
-@pytest.mark.parametrize("wavelet", ["db1", "db2"])
+@pytest.mark.parametrize("size", [[32], [1, 32], [3, 64], [5, 64]])
+@pytest.mark.parametrize("wavelet", ["db1", "db2", "db3", "db4"])
 def test_swt_1d(level: Optional[int], size: int, wavelet: str) -> None:
     """Test the 1d swt."""
     signal = np.random.normal(size=size).astype(np.float64)


### PR DESCRIPTION
Some combinations of wavelets and number of decomposition steps cause the following `RuntimeError`: "Padding value causes wrapping around more than once".
If the padding values are greater than the input length, `torch.nn.functional.pad` does not wrap around more than once in circluar mode. We need to manually wrap around more than once, if needed. See feature request [https://github.com/pytorch/pytorch/issues/57911](url) in PyTorch.