### PR TITLE
Reorganize requirements

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -39,8 +39,7 @@ def lint(session):
 @nox.session(name="typing")
 def mypy(session):
     """Check type hints."""
-    session.install(".")
-    session.install("mypy")
+    session.install(".[typing]")
     session.run(
         "mypy",
         "--install-types",

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,6 +8,7 @@ def run_test(session):
     """Run pytest."""
     session.install(".")
     session.install("pytest")
+    session.install("scipy")
     session.run("pytest")
 
 
@@ -16,6 +17,7 @@ def run_test_fast(session):
     """Run pytest."""
     session.install(".")
     session.install("pytest")
+    session.install("scipy")
     session.run("pytest", "-m", "not slow")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,18 +6,14 @@ import nox
 @nox.session(name="test")
 def run_test(session):
     """Run pytest."""
-    session.install(".")
-    session.install("pytest")
-    session.install("scipy")
+    session.install(".[tests]")
     session.run("pytest")
 
 
 @nox.session(name="fast-test")
 def run_test_fast(session):
     """Run pytest."""
-    session.install(".")
-    session.install("pytest")
-    session.install("scipy")
+    session.install(".[tests]")
     session.run("pytest", "-m", "not slow")
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,12 +49,7 @@ classifiers =
 install_requires =
     PyWavelets
     torch
-    scipy>=1.10
-    pooch
-    matplotlib
     numpy
-    pytest
-    nox
 
 python_requires = >=3.9
 
@@ -65,6 +60,13 @@ package_dir =
 [options.packages.find]
 where = src
 
+[options.extras_require]
+tests =
+    nox
+examples =
+    matplotlib
+    scipy>=1.10
+    pooch
 
 ##########################
 # Darglint Configuration #

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,9 +64,10 @@ where = src
 tests =
     pytest
     scipy>=1.10
+    # pooch is an optional scipy dependency for getting datasets
+    pooch
 examples =
     matplotlib
-    pooch
 
 ##########################
 # Darglint Configuration #

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,9 @@ tests =
     scipy>=1.10
     # pooch is an optional scipy dependency for getting datasets
     pooch
+typing =
+    mypy
+    pytest
 examples =
     matplotlib
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,10 +62,10 @@ where = src
 
 [options.extras_require]
 tests =
-    nox
+    pytest
+    scipy>=1.10
 examples =
     matplotlib
-    scipy>=1.10
     pooch
 
 ##########################

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ tests =
     pooch
 typing =
     mypy
+    # needed otherwise pytest decorators don't get typed properly
     pytest
 examples =
     matplotlib


### PR DESCRIPTION
The main functionality of this package actually doesn't use several of the currently listed requirements, so I reorganized them.

1. `matplotlib` is used for some of the examples, so I made an optional group
2. `nox` is used to run the tests, but itself takes care of specifying the requirements for its environments, so they don't have to be configured here
3. `pytest`, `scipy`, `pooch` are used in tests so I made an optional group to define these and upstreamed it from the noxfile