### PR TITLE
Fix non-default axis in packets

### DIFF
--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -467,7 +467,7 @@ class WaveletPacket2D(BaseDict):
         return _fsdict_func
 
     def _recursive_dwt2d(self, data: torch.Tensor, level: int, path: str) -> None:
-        if not self.maxlevel:
+        if self.maxlevel is None:
             raise AssertionError
 
         self.data[path] = data

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -226,7 +226,7 @@ class WaveletPacket(BaseDict):
             return graycode_order
 
     def _recursive_dwt(self, data: torch.Tensor, level: int, path: str) -> None:
-        if not self.maxlevel:
+        if self.maxlevel is None:
             raise AssertionError
 
         self.data[path] = data

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -113,9 +113,6 @@ class WaveletPacket(BaseDict):
         self.maxlevel: Optional[int] = None
         self.axis = axis
         if data is not None:
-            if len(data.shape) == 1:
-                # add a batch dimension.
-                data = data.unsqueeze(0)
             self.transform(data, maxlevel)
         else:
             self.data = {}

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -2,7 +2,6 @@
 
 # Created on Fri Apr 6 2021 by moritz (wolter@cs.uni-bonn.de)
 
-from itertools import product
 from typing import Optional
 
 import numpy as np

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -136,6 +136,7 @@ def _compare_trees2(
 @pytest.mark.parametrize("batch_size", [2, 1])
 @pytest.mark.parametrize("transform_mode", [False, True])
 @pytest.mark.parametrize("multiple_transforms", [False, True])
+@pytest.mark.parametrize("axes", [(-2, -1), (-1, -2), (1, 2), (2, 0), (0, 2)])
 def test_2d_packets(
     max_lev: Optional[int],
     wavelet_str: str,
@@ -143,6 +144,7 @@ def test_2d_packets(
     batch_size: int,
     transform_mode: bool,
     multiple_transforms: bool,
+    axes: tuple[int, int],
 ) -> None:
     """Ensure pywt and ptwt produce equivalent wavelet 2d packet trees."""
     _compare_trees2(
@@ -153,6 +155,7 @@ def test_2d_packets(
         batch_size=batch_size,
         transform_mode=transform_mode,
         multiple_transforms=multiple_transforms,
+        axes=axes,
     )
 
 
@@ -161,11 +164,13 @@ def test_2d_packets(
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("transform_mode", [False, True])
 @pytest.mark.parametrize("multiple_transforms", [False, True])
+@pytest.mark.parametrize("axes", [(-2, -1), (-1, -2), (1, 2), (2, 0), (0, 2)])
 def test_boundary_matrix_packets2(
     max_lev: Optional[int],
     batch_size: int,
     transform_mode: bool,
     multiple_transforms: bool,
+    axes: tuple[int, int],
 ) -> None:
     """Ensure the 2d - sparse matrix haar tree and pywt-tree are the same."""
     _compare_trees2(
@@ -176,6 +181,7 @@ def test_boundary_matrix_packets2(
         batch_size=batch_size,
         transform_mode=transform_mode,
         multiple_transforms=multiple_transforms,
+        axes=axes,
     )
 
 
@@ -188,6 +194,7 @@ def test_boundary_matrix_packets2(
 @pytest.mark.parametrize("batch_size", [2, 1])
 @pytest.mark.parametrize("transform_mode", [False, True])
 @pytest.mark.parametrize("multiple_transforms", [False, True])
+@pytest.mark.parametrize("axis", [0, -1])
 def test_1d_packets(
     max_lev: int,
     wavelet_str: str,
@@ -195,6 +202,7 @@ def test_1d_packets(
     batch_size: int,
     transform_mode: bool,
     multiple_transforms: bool,
+    axis: int,
 ) -> None:
     """Ensure pywt and ptwt produce equivalent wavelet 1d packet trees."""
     _compare_trees1(
@@ -205,6 +213,7 @@ def test_1d_packets(
         batch_size=batch_size,
         transform_mode=transform_mode,
         multiple_transforms=multiple_transforms,
+        axis=axis,
     )
 
 

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -263,10 +263,10 @@ def test_freq_order(level: int, wavelet_str: str, pywt_boundary: str) -> None:
             print(
                 level,
                 order_el.path,
-                "".join(tree_el),
-                order_el.path == "".join(tree_el),
+                tree_el,
+                order_el.path == tree_el,
             )
-            assert order_el.path == "".join(tree_el)
+            assert order_el.path == tree_el
 
 
 def test_packet_harbo_lvl3() -> None:

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -11,6 +11,7 @@ import pywt
 import torch
 from scipy import datasets
 
+from ptwt._util import _check_axes_argument
 from ptwt.constants import ExtendedBoundaryMode
 from ptwt.packets import WaveletPacket, WaveletPacket2D
 
@@ -27,6 +28,8 @@ def _compare_trees1(
     axis: int = -1,
 ) -> None:
     data = np.random.rand(batch_size, length)
+    data = data.swapaxes(axis, -1)
+
     if transform_mode:
         twp = WaveletPacket(
             None,
@@ -78,6 +81,10 @@ def _compare_trees2(
 ) -> None:
     face = datasets.face()[:height, :width].astype(np.float64).mean(-1)
     data = np.stack([face] * batch_size, 0)
+
+    _check_axes_argument(axes)
+    data = data.swapaxes(axes[0], -2)
+    data = data.swapaxes(axes[1], -1)
 
     wp_tree = pywt.WaveletPacket2D(
         data=data,


### PR DESCRIPTION
The logic in the WaveletPacket objects so far ignored the axis argument and always accessed the last axes, e.g. to lookup which transform to use.

This PR addresses this and extends the unit tests to cover different axes choices.