### PR TITLE
Improve packets order interface

### DIFF
--- a/src/ptwt/constants.py
+++ b/src/ptwt/constants.py
@@ -51,6 +51,14 @@ The method for orthogonalizing a matrix.
 Choose ``gramschmidt`` if ``qr`` runs out of memory.
 """
 
+PacketNodeOrder = Literal["freq", "natural"]
+"""
+This is a type literal for the order of wavelet packet tree nodes.
+
+- frequency order (``freq``)
+- natural order (``natural``)
+"""
+
 
 class WaveletDetailTuple2d(NamedTuple):
     """Detail coefficients of a 2d wavelet transform for a given level.

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -531,6 +531,17 @@ class WaveletPacket2D(BaseDict):
         return super().__getitem__(key)
 
     @staticmethod
+    def get_level(level: int, order: str = "freq") -> Union[list[str], list[list[str]]]:
+        if order == "freq":
+            return WaveletPacket2D.get_freq_order(level)
+        elif order == "natural":
+            return WaveletPacket2D.get_natural_order(level)
+        else:
+            raise ValueError(
+                f"Unsupported order '{order}'. Choose from 'freq' and 'natural'."
+            )
+
+    @staticmethod
     def get_natural_order(level: int) -> list[str]:
         """Get the natural ordering for a given decomposition level.
 

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -16,6 +16,7 @@ from ._util import Wavelet, _as_wavelet
 from .constants import (
     ExtendedBoundaryMode,
     OrthogonalizeMethod,
+    PacketNodeOrder,
     WaveletCoeff2d,
     WaveletCoeffNd,
     WaveletDetailTuple2d,
@@ -205,7 +206,7 @@ class WaveletPacket(BaseDict):
             return partial(waverec, wavelet=self.wavelet, axis=self.axis)
 
     @staticmethod
-    def get_level(level: int, order: Literal["freq", "natural"] = "freq") -> list[str]:
+    def get_level(level: int, order: PacketNodeOrder = "freq") -> list[str]:
         """Return the paths to the filter tree nodes.
 
         Args:
@@ -540,7 +541,7 @@ class WaveletPacket2D(BaseDict):
 
     @staticmethod
     def get_level(
-        level: int, order: Literal["freq", "natural"] = "freq"
+        level: int, order: PacketNodeOrder = "freq"
     ) -> Union[list[str], list[list[str]]]:
         """Return the paths to the filter tree nodes.
 

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -204,7 +204,8 @@ class WaveletPacket(BaseDict):
         else:
             return partial(waverec, wavelet=self.wavelet, axis=self.axis)
 
-    def get_level(self, level: int, order: str = "freq") -> list[str]:
+    @staticmethod
+    def get_level(level: int, order: str = "freq") -> list[str]:
         """Return the paths to the filter tree nodes.
 
         Args:
@@ -221,7 +222,7 @@ class WaveletPacket(BaseDict):
             ValueError: If `order` is neither ``freq`` nor ``natural``.
         """
         if order == "freq":
-            return self._get_graycode_order(level)
+            return WaveletPacket._get_graycode_order(level)
         elif order == "natural":
             return ["".join(p) for p in product(["a", "d"], repeat=level)]
         else:
@@ -229,7 +230,8 @@ class WaveletPacket(BaseDict):
                 f"Unsupported order '{order}'. Choose from 'freq' and 'natural'."
             )
 
-    def _get_graycode_order(self, level: int, x: str = "a", y: str = "d") -> list[str]:
+    @staticmethod
+    def _get_graycode_order(level: int, x: str = "a", y: str = "d") -> list[str]:
         graycode_order = [x, y]
         for _ in range(level - 1):
             graycode_order = [x + path for path in graycode_order] + [

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -6,7 +6,7 @@ import collections
 from collections.abc import Sequence
 from functools import partial
 from itertools import product
-from typing import TYPE_CHECKING, Callable, Literal, Optional, Union
+from typing import TYPE_CHECKING, Callable, Literal, Optional, Union, overload
 
 import numpy as np
 import pywt
@@ -529,6 +529,14 @@ class WaveletPacket2D(BaseDict):
                 f"maximum level {self.maxlevel}."
             )
         return super().__getitem__(key)
+
+    @overload
+    @staticmethod
+    def get_level(level: int, order: Literal["freq"]) -> list[list[str]]: ...
+
+    @overload
+    @staticmethod
+    def get_level(level: int, order: Literal["natural"]) -> list[str]: ...
 
     @staticmethod
     def get_level(

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -210,7 +210,7 @@ class WaveletPacket(BaseDict):
 
         Args:
             level (int): The depth of the tree.
-            order (str): The order the paths are in.
+            order: The order the paths are in.
                 Choose from frequency order (``freq``) and
                 natural order (``natural``).
                 Defaults to ``freq``.
@@ -542,6 +542,21 @@ class WaveletPacket2D(BaseDict):
     def get_level(
         level: int, order: Literal["freq", "natural"] = "freq"
     ) -> Union[list[str], list[list[str]]]:
+        """Return the paths to the filter tree nodes.
+
+        Args:
+            level (int): The depth of the tree.
+            order: The order the paths are in.
+                Choose from frequency order (``freq``) and
+                natural order (``natural``).
+                Defaults to ``freq``.
+
+        Returns:
+            A list with the paths to each node.
+
+        Raises:
+            ValueError: If `order` is neither ``freq`` nor ``natural``.
+        """
         if order == "freq":
             return WaveletPacket2D.get_freq_order(level)
         elif order == "natural":

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -6,7 +6,7 @@ import collections
 from collections.abc import Sequence
 from functools import partial
 from itertools import product
-from typing import TYPE_CHECKING, Callable, Optional, Union
+from typing import TYPE_CHECKING, Callable, Literal, Optional, Union
 
 import numpy as np
 import pywt
@@ -205,7 +205,7 @@ class WaveletPacket(BaseDict):
             return partial(waverec, wavelet=self.wavelet, axis=self.axis)
 
     @staticmethod
-    def get_level(level: int, order: str = "freq") -> list[str]:
+    def get_level(level: int, order: Literal["freq", "natural"] = "freq") -> list[str]:
         """Return the paths to the filter tree nodes.
 
         Args:
@@ -531,7 +531,9 @@ class WaveletPacket2D(BaseDict):
         return super().__getitem__(key)
 
     @staticmethod
-    def get_level(level: int, order: str = "freq") -> Union[list[str], list[list[str]]]:
+    def get_level(
+        level: int, order: Literal["freq", "natural"] = "freq"
+    ) -> Union[list[str], list[list[str]]]:
         if order == "freq":
             return WaveletPacket2D.get_freq_order(level)
         elif order == "natural":

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -204,16 +204,30 @@ class WaveletPacket(BaseDict):
         else:
             return partial(waverec, wavelet=self.wavelet, axis=self.axis)
 
-    def get_level(self, level: int) -> list[str]:
-        """Return the graycode-ordered paths to the filter tree nodes.
+    def get_level(self, level: int, order: str = "freq") -> list[str]:
+        """Return the paths to the filter tree nodes.
 
         Args:
             level (int): The depth of the tree.
+            order (str): The order the paths are in.
+                Choose from frequency order (``freq``) and
+                natural order (``natural``).
+                Defaults to ``freq``.
 
         Returns:
             A list with the paths to each node.
+
+        Raises:
+            ValueError: If `order` is neither ``freq`` nor ``natural``.
         """
-        return self._get_graycode_order(level)
+        if order == "freq":
+            return self._get_graycode_order(level)
+        elif order == "natural":
+            return ["".join(p) for p in product(["a", "d"], repeat=level)]
+        else:
+            raise ValueError(
+                f"Unsupported order '{order}'. Choose from 'freq' and 'natural'."
+            )
 
     def _get_graycode_order(self, level: int, x: str = "a", y: str = "d") -> list[str]:
         graycode_order = [x, y]

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -225,6 +225,26 @@ def test_boundary_matrix_packets1(
 @pytest.mark.parametrize("level", [1, 2, 3, 4])
 @pytest.mark.parametrize("wavelet_str", ["db2"])
 @pytest.mark.parametrize("pywt_boundary", ["zero"])
+@pytest.mark.parametrize("order", ["freq", "natural"])
+def test_order_1d(level: int, wavelet_str: str, pywt_boundary: str, order: str) -> None:
+    """Test the packets in natural order."""
+    data = np.random.rand(2, 256)
+    wp_tree = pywt.WaveletPacket(
+        data=data,
+        wavelet=wavelet_str,
+        mode=pywt_boundary,
+    )
+    # Get the full decomposition
+    order_pywt = wp_tree.get_level(level, order)
+    order_ptwt = WaveletPacket.get_level(level, order)
+
+    for order_el, order_path in zip(order_pywt, order_ptwt):
+        assert order_el.path == order_path
+
+
+@pytest.mark.parametrize("level", [1, 2, 3, 4])
+@pytest.mark.parametrize("wavelet_str", ["db2"])
+@pytest.mark.parametrize("pywt_boundary", ["zero"])
 def test_freq_order(level: int, wavelet_str: str, pywt_boundary: str) -> None:
     """Test the packets in frequency order."""
     face = datasets.face()

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -249,6 +249,26 @@ def test_freq_order(level: int, wavelet_str: str, pywt_boundary: str) -> None:
             assert order_el.path == "".join(tree_el)
 
 
+@pytest.mark.parametrize("level", [1, 2, 3, 4])
+@pytest.mark.parametrize("wavelet_str", ["db2"])
+@pytest.mark.parametrize("pywt_boundary", ["zero"])
+def test_natural_order_2d(level: int, wavelet_str: str, pywt_boundary: str) -> None:
+    """Test the packets in natural order."""
+    face = datasets.face()
+    wavelet = pywt.Wavelet(wavelet_str)
+    wp_tree = pywt.WaveletPacket2D(
+        data=np.mean(face, axis=-1).astype(np.float64),
+        wavelet=wavelet,
+        mode=pywt_boundary,
+    )
+    # Get the full decomposition
+    order_pywt = wp_tree.get_level(level, "natural")
+    order_ptwt = WaveletPacket2D.get_natural_order(level)
+
+    for order_el, order_path in zip(order_pywt, order_ptwt):
+        assert order_el.path == order_path
+
+
 def test_packet_harbo_lvl3() -> None:
     """From Jensen, La Cour-Harbo, Rippels in Mathematics, Chapter 8 (page 89)."""
     data = np.array([56.0, 40.0, 8.0, 24.0, 48.0, 48.0, 40.0, 16.0])


### PR DESCRIPTION
* Makes `WaveletPacket.get_level` static
* Adds Option for `WaveletPacket.get_level` to return the 1d natural order.
* Adds `WaveletPacket2D.get_level` to have a consistent interface (with our 1d case as well as pywt)
* Adds unit tests for both 1d orders and 2d natural order