### PR TITLE
Add lazy init to packets for partial tree expansion

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,10 +8,10 @@
 PyTorch Wavelet Toolbox (``ptwt``)
 ==================================
 
-``ptwt`` brings wavelet transforms to PyTorch. The code is open-source, follow the link above
-to go to the source. This package is listed in the Python Package Index (PyPI). Its best installed via pip.
+``ptwt`` brings wavelet transforms to PyTorch. The code is open-source, follow the GitHub link above
+to go to the source. This package is listed in the Python Package Index (PyPI). It's best installed via pip.
 GPU support depends on PyTorch. To take advantage of GPU-processing follow the `PyTorch install instructions`_.
-Install the version that best suits your systems hardware setup. Once PyTorch ist set up, type the following
+Install the version that best suits your system's hardware setup. Once PyTorch is set up, type the following
 to get started:
 
 .. code-block:: sh
@@ -20,12 +20,12 @@ to get started:
 
 This documentation aims to explain the foundations of wavelet theory, introduce the ``ptwt`` package by example, and
 deliver a complete documentation of all functions. Readers who are already familiar with the theory should directly
-jump to the examples or the API-documentation using the navigation on the left.
+jump to the examples or the API documentation using the navigation on the left.
 
 ``ptwt`` is built to be `PyWavelets <https://pywavelets.readthedocs.io/en/latest/>`_ compatible.
 It should be possible to switch back and forth with relative ease.
 
-If you use this work in a scientific context, please cite the following thesis:
+If you use this work in a scientific context, please cite the following paper:
 
 .. code-block::
 

--- a/examples/deepfake_analysis/packet_plot.py
+++ b/examples/deepfake_analysis/packet_plot.py
@@ -68,7 +68,7 @@ def load_images(path: str) -> list:
 
 if __name__ == "__main__":
     freq_path = ptwt.WaveletPacket2D.get_freq_order(level=3)
-    frequency_path = ptwt.WaveletPacket2D.get_natural_order(level=3)
+    natural_path = ptwt.WaveletPacket2D.get_natural_order(level=3)
     print("Loading ffhq images:")
     ffhq_images = load_images("./ffhq_style_gan/source_data/A_ffhq")
     print("processing ffhq")

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -112,6 +112,9 @@ class WaveletPacket(BaseDict):
         self._matrix_waverec_dict: dict[int, MatrixWaverec] = {}
         self.maxlevel: Optional[int] = None
         self.axis = axis
+
+        self._filter_keys = {"a", "d"}
+
         if data is not None:
             self.transform(data, maxlevel)
         else:
@@ -188,12 +191,9 @@ class WaveletPacket(BaseDict):
             for node in self.get_level(level):
                 # check if any children is not available
                 # we need to check manually to avoid lazy init
-                def _test_key(key: str) -> None:
-                    if key not in self:
-                        raise KeyError(f"Key {key} not found")
-
-                for child in ["a", "d"]:
-                    _test_key(node + child)
+                for child in self._filter_keys:
+                    if node + child not in self:
+                        raise KeyError(f"Key {node + child} not found")
 
                 data_a = self[node + "a"]
                 data_d = self[node + "d"]
@@ -315,6 +315,11 @@ class WaveletPacket(BaseDict):
                     "The wavelet packet tree is not properly initialized. "
                     "Run `transform` before accessing tree values."
                 )
+            elif key[-1] not in self._filter_keys:
+                raise ValueError(
+                    f"Invalid key '{key}'. All chars in the key must be of the "
+                    f"set {self._filter_keys}."
+                )
             # calculate data from parent
             self._expand_node(key[:-1])
         return super().__getitem__(key)
@@ -375,6 +380,7 @@ class WaveletPacket2D(BaseDict):
         self.matrix_wavedec2_dict: dict[tuple[int, ...], MatrixWavedec2] = {}
         self.matrix_waverec2_dict: dict[tuple[int, ...], MatrixWaverec2] = {}
         self.axes = axes
+        self._filter_keys = {"a", "h", "v", "d"}
 
         self.maxlevel: Optional[int] = None
         if data is not None:
@@ -442,12 +448,9 @@ class WaveletPacket2D(BaseDict):
             for node in WaveletPacket2D.get_natural_order(level):
                 # check if any children is not available
                 # we need to check manually to avoid lazy init
-                def _test_key(key: str) -> None:
-                    if key not in self:
-                        raise KeyError(f"Key {key} not found")
-
-                for child in ["a", "h", "v", "d"]:
-                    _test_key(node + child)
+                for child in self._filter_keys:
+                    if node + child not in self:
+                        raise KeyError(f"Key {node + child} not found")
 
                 data_a = self[node + "a"]
                 data_h = self[node + "h"]
@@ -604,6 +607,11 @@ class WaveletPacket2D(BaseDict):
                     "The requested root of the packet tree cannot be accessed! "
                     "The wavelet packet tree is not properly initialized. "
                     "Run `transform` before accessing tree values."
+                )
+            elif key[-1] not in self._filter_keys:
+                raise ValueError(
+                    f"Invalid key '{key}'. All chars in the key must be of the "
+                    f"set {self._filter_keys}."
                 )
             # calculate data from parent
             self._expand_node(key[:-1])

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import collections
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from functools import partial
 from itertools import product
-from typing import TYPE_CHECKING, Callable, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 import pywt
@@ -108,7 +108,6 @@ class WaveletPacket(BaseDict):
             >>> viz = np.stack(np_lst).squeeze()
             >>> plt.imshow(np.abs(viz))
             >>> plt.show()
-
         """
         self.wavelet = _as_wavelet(wavelet)
         self.mode = mode
@@ -143,6 +142,9 @@ class WaveletPacket(BaseDict):
                 This allows for partial expansion of the wavelet packet tree.
                 Otherwise, all packet coefficients up to the decomposition level
                 `maxlevel` are computed. Defaults to False.
+
+        Returns:
+            This wavelet packet object (to allow call chaining).
         """
         self.data = {"": data}
         if maxlevel is None:
@@ -344,7 +346,6 @@ class WaveletPacket2D(BaseDict):
                 If True, the packet tree is initialized lazily. This
                 allows for partial expansion of the wavelet packet tree.
                 Defaults to False.
-
         """
         self.wavelet = _as_wavelet(wavelet)
         self.mode = mode
@@ -380,6 +381,9 @@ class WaveletPacket2D(BaseDict):
                 This allows for partial expansion of the wavelet packet tree.
                 Otherwise, all packet coefficients up to the decomposition level
                 `maxlevel` are computed. Defaults to False.
+
+        Returns:
+            This wavelet packet object (to allow call chaining).
         """
         self.data = {"": data}
         if maxlevel is None:

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -61,6 +61,7 @@ class WaveletPacket(BaseDict):
         maxlevel: Optional[int] = None,
         axis: int = -1,
         boundary_orthogonalization: OrthogonalizeMethod = "qr",
+        lazy_init: bool = False,
     ) -> None:
         """Create a wavelet packet decomposition object.
 
@@ -116,12 +117,15 @@ class WaveletPacket(BaseDict):
             if len(data.shape) == 1:
                 # add a batch dimension.
                 data = data.unsqueeze(0)
-            self.transform(data, maxlevel)
+            self.transform(data, maxlevel, lazy_init=lazy_init)
         else:
             self.data = {}
 
     def transform(
-        self, data: torch.Tensor, maxlevel: Optional[int] = None
+        self,
+        data: torch.Tensor,
+        maxlevel: Optional[int] = None,
+        lazy_init: bool = False,
     ) -> WaveletPacket:
         """Calculate the 1d wavelet packet transform for the input data.
 
@@ -136,7 +140,8 @@ class WaveletPacket(BaseDict):
         if maxlevel is None:
             maxlevel = pywt.dwt_max_level(data.shape[-1], self.wavelet.dec_len)
         self.maxlevel = maxlevel
-        self._recursive_dwt(path="")
+        if not lazy_init:
+            self._recursive_dwt(path="")
         return self
 
     def reconstruct(self) -> WaveletPacket:
@@ -299,6 +304,7 @@ class WaveletPacket2D(BaseDict):
         axes: tuple[int, int] = (-2, -1),
         boundary_orthogonalization: OrthogonalizeMethod = "qr",
         separable: bool = False,
+        lazy_init: bool = False,
     ) -> None:
         """Create a 2D-Wavelet packet tree.
 
@@ -338,12 +344,15 @@ class WaveletPacket2D(BaseDict):
 
         self.maxlevel: Optional[int] = None
         if data is not None:
-            self.transform(data, maxlevel)
+            self.transform(data, maxlevel, lazy_init=lazy_init)
         else:
             self.data = {}
 
     def transform(
-        self, data: torch.Tensor, maxlevel: Optional[int] = None
+        self,
+        data: torch.Tensor,
+        maxlevel: Optional[int] = None,
+        lazy_init: bool = False,
     ) -> WaveletPacket2D:
         """Calculate the 2d wavelet packet transform for the input data.
 
@@ -365,7 +374,8 @@ class WaveletPacket2D(BaseDict):
             # add batch dim to unbatched input
             data = data.unsqueeze(0)
 
-        self._recursive_dwt2d(path="")
+        if not lazy_init:
+            self._recursive_dwt2d(path="")
         return self
 
     def reconstruct(self) -> WaveletPacket2D:

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -146,6 +146,16 @@ class WaveletPacket(BaseDict):
         self.maxlevel = maxlevel
         return self
 
+    def initialize(self, keys: Iterable[str]) -> None:
+        """Initialize the wavelet packet tree partially.
+
+        Args:
+            keys (Iterable[str]): An iterable yielding the keys of the
+                tree nodes to initialize.
+        """
+        it = (self[key] for key in keys)
+        collections.deque(it, maxlen=0)
+
     def reconstruct(self) -> WaveletPacket:
         """Recursively reconstruct the input starting from the leaf nodes.
 
@@ -402,6 +412,16 @@ class WaveletPacket2D(BaseDict):
         self.maxlevel = maxlevel
 
         return self
+
+    def initialize(self, keys: Iterable[str]) -> None:
+        """Initialize the wavelet packet tree partially.
+
+        Args:
+            keys (Iterable[str]): An iterable yielding the keys of the
+                tree nodes to initialize.
+        """
+        it = (self[key] for key in keys)
+        collections.deque(it, maxlen=0)
 
     def reconstruct(self) -> WaveletPacket2D:
         """Recursively reconstruct the input starting from the leaf nodes.

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -273,7 +273,8 @@ class WaveletPacket(BaseDict):
 
         Raises:
             ValueError: If the wavelet packet tree is not initialized.
-            KeyError: If no wavelet coefficients are indexed by the specified key.
+            KeyError: If no wavelet coefficients are indexed by the specified key
+                and a lazy initialization fails.
         """
         if self.maxlevel is None:
             raise ValueError(
@@ -555,7 +556,8 @@ class WaveletPacket2D(BaseDict):
 
         Raises:
             ValueError: If the wavelet packet tree is not initialized.
-            KeyError: If no wavelet coefficients are indexed by the specified key.
+            KeyError: If no wavelet coefficients are indexed by the specified key
+                and a lazy initialization fails.
         """
         if self.maxlevel is None:
             raise ValueError(

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import collections
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from functools import partial
 from itertools import product
 from typing import TYPE_CHECKING, Literal, Optional, Union, overload
@@ -62,11 +62,12 @@ class WaveletPacket(BaseDict):
         maxlevel: Optional[int] = None,
         axis: int = -1,
         boundary_orthogonalization: OrthogonalizeMethod = "qr",
-        lazy_init: bool = False,
     ) -> None:
         """Create a wavelet packet decomposition object.
 
-        The decompositions will rely on padded fast wavelet transforms.
+        The packet tree is initialized lazily, i.e. a coefficient is only
+        calculated as it is retrieved. This allows for partial expansion
+        of the wavelet packet tree.
 
         Args:
             data (torch.Tensor, optional): The input data array of shape ``[time]``,
@@ -89,10 +90,6 @@ class WaveletPacket(BaseDict):
                 to use in the sparse matrix backend,
                 see :data:`ptwt.constants.OrthogonalizeMethod`.
                 Only used if `mode` equals 'boundary'. Defaults to 'qr'.
-            lazy_init (bool): Value is passed on to :func:`transform`.
-                If True, the packet tree is initialized lazily. This
-                allows for partial expansion of the wavelet packet tree.
-                Defaults to False.
 
         Example:
             >>> import torch, pywt, ptwt
@@ -116,7 +113,7 @@ class WaveletPacket(BaseDict):
         self.maxlevel: Optional[int] = None
         self.axis = axis
         if data is not None:
-            self.transform(data, maxlevel, lazy_init=lazy_init)
+            self.transform(data, maxlevel)
         else:
             self.data = {}
 
@@ -124,9 +121,14 @@ class WaveletPacket(BaseDict):
         self,
         data: torch.Tensor,
         maxlevel: Optional[int] = None,
-        lazy_init: bool = False,
     ) -> WaveletPacket:
-        """Calculate the 1d wavelet packet transform for the input data.
+        """Lazily calculate the 1d wavelet packet transform for the input data.
+
+        The packet tree is initialized lazily, i.e. a coefficient is only
+        calculated as it is retrieved. This allows for partial expansion
+        of the wavelet packet tree.
+
+        The transform function allows reusing the same object.
 
         Args:
             data (torch.Tensor): The input data array of shape ``[time]``
@@ -134,10 +136,6 @@ class WaveletPacket(BaseDict):
             maxlevel (int, optional): The highest decomposition level to compute.
                 If None, the maximum level is determined from the input data shape.
                 Defaults to None.
-            lazy_init (bool): If True, the packet tree is initialized lazily.
-                This allows for partial expansion of the wavelet packet tree.
-                Otherwise, all packet coefficients up to the decomposition level
-                `maxlevel` are computed. Defaults to False.
 
         Returns:
             This wavelet packet object (to allow call chaining).
@@ -146,8 +144,6 @@ class WaveletPacket(BaseDict):
         if maxlevel is None:
             maxlevel = pywt.dwt_max_level(data.shape[self.axis], self.wavelet.dec_len)
         self.maxlevel = maxlevel
-        if not lazy_init:
-            self._recursive_dwt(path="")
         return self
 
     def reconstruct(self) -> WaveletPacket:
@@ -166,9 +162,14 @@ class WaveletPacket(BaseDict):
             >>> signal = np.random.randn(1, 16)
             >>> ptwp = ptwt.WaveletPacket(torch.from_numpy(signal), "haar",
             >>>     mode="boundary", maxlevel=2)
-            >>> ptwp["aa"].data *= 0
+            >>> # initialize other leaf nodes
+            >>> ptwp.initialize(["ad", "da", "dd"])
+            >>> ptwp["aa"] = torch.zeros_like(ptwp["ad"])
             >>> ptwp.reconstruct()
             >>> print(ptwp[""])
+
+        Raises:
+            KeyError: if any leaf node data is not present.
         """
         if self.maxlevel is None:
             self.maxlevel = pywt.dwt_max_level(self[""].shape[-1], self.wavelet.dec_len)
@@ -270,19 +271,6 @@ class WaveletPacket(BaseDict):
         self.data[path + "a"] = res_lo
         self.data[path + "d"] = res_hi
 
-    def _recursive_dwt(self, path: str) -> None:
-        if self.maxlevel is None:
-            raise AssertionError
-
-        if len(path) >= self.maxlevel:
-            # nothing to expand
-            return
-
-        self._expand_node(path)
-
-        for child in ["a", "d"]:
-            self._recursive_dwt(path + child)
-
     def __getitem__(self, key: str) -> torch.Tensor:
         """Access the coefficients in the wavelet packets tree.
 
@@ -338,9 +326,12 @@ class WaveletPacket2D(BaseDict):
         axes: tuple[int, int] = (-2, -1),
         boundary_orthogonalization: OrthogonalizeMethod = "qr",
         separable: bool = False,
-        lazy_init: bool = False,
     ) -> None:
         """Create a 2D-Wavelet packet tree.
+
+        The packet tree is initialized lazily, i.e. a coefficient is only
+        calculated as it is retrieved. This allows for partial expansion
+        of the wavelet packet tree.
 
         Args:
             data (torch.tensor, optional): The input data tensor.
@@ -366,10 +357,6 @@ class WaveletPacket2D(BaseDict):
                 Only used if `mode` equals 'boundary'. Defaults to 'qr'.
             separable (bool): If true, a separable transform is performed,
                 i.e. each image axis is transformed separately. Defaults to False.
-            lazy_init (bool): Value is passed on to :func:`transform`.
-                If True, the packet tree is initialized lazily. This
-                allows for partial expansion of the wavelet packet tree.
-                Defaults to False.
         """
         self.wavelet = _as_wavelet(wavelet)
         self.mode = mode
@@ -381,7 +368,7 @@ class WaveletPacket2D(BaseDict):
 
         self.maxlevel: Optional[int] = None
         if data is not None:
-            self.transform(data, maxlevel, lazy_init=lazy_init)
+            self.transform(data, maxlevel)
         else:
             self.data = {}
 
@@ -389,11 +376,14 @@ class WaveletPacket2D(BaseDict):
         self,
         data: torch.Tensor,
         maxlevel: Optional[int] = None,
-        lazy_init: bool = False,
     ) -> WaveletPacket2D:
-        """Calculate the 2d wavelet packet transform for the input data.
+        """Lazily calculate the 2d wavelet packet transform for the input data.
 
-           The transform function allows reusing the same object.
+        The packet tree is initialized lazily, i.e. a coefficient is only
+        calculated as it is retrieved. This allows for partial expansion
+        of the wavelet packet tree.
+
+        The transform function allows reusing the same object.
 
         Args:
             data (torch.tensor): The input data tensor
@@ -401,10 +391,6 @@ class WaveletPacket2D(BaseDict):
             maxlevel (int, optional): The highest decomposition level to compute.
                 If None, the maximum level is determined from the input data shape.
                 Defaults to None.
-            lazy_init (bool): If True, the packet tree is initialized lazily.
-                This allows for partial expansion of the wavelet packet tree.
-                Otherwise, all packet coefficients up to the decomposition level
-                `maxlevel` are computed. Defaults to False.
 
         Returns:
             This wavelet packet object (to allow call chaining).
@@ -415,8 +401,6 @@ class WaveletPacket2D(BaseDict):
             maxlevel = pywt.dwt_max_level(min_transform_size, self.wavelet.dec_len)
         self.maxlevel = maxlevel
 
-        if not lazy_init:
-            self._recursive_dwt2d(path="")
         return self
 
     def reconstruct(self) -> WaveletPacket2D:
@@ -426,6 +410,9 @@ class WaveletPacket2D(BaseDict):
            Only changes to leaf node data impact the results,
            since changes in all other nodes will be replaced with
            a reconstruction from the leaves.
+
+        Raises:
+            KeyError: if any leaf node data is not present.
         """
         if self.maxlevel is None:
             min_transform_size = min(_swap_axes(self[""], self.axes).shape[-2:])
@@ -560,18 +547,6 @@ class WaveletPacket2D(BaseDict):
             return fsdict_func((a, {"ad": h, "da": v, "dd": d}))
 
         return _fsdict_func
-
-    def _recursive_dwt2d(self, path: str) -> None:
-        if self.maxlevel is None:
-            raise AssertionError
-
-        if len(path) >= self.maxlevel:
-            # nothing to expand
-            return
-
-        self._expand_node(path)
-        for child in ["a", "h", "v", "d"]:
-            self._recursive_dwt2d(path + child)
 
     def __getitem__(self, key: str) -> torch.Tensor:
         """Access the coefficients in the wavelet packets tree.

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -102,9 +102,7 @@ class WaveletPacket(BaseDict):
             >>> w = scipy.signal.chirp(t, f0=1, f1=50, t1=10, method="linear")
             >>> wp = ptwt.WaveletPacket(data=torch.from_numpy(w.astype(np.float32)),
             >>>     wavelet=pywt.Wavelet("db3"), mode="reflect")
-            >>> np_lst = []
-            >>> for node in wp.get_level(5):
-            >>>     np_lst.append(wp[node])
+            >>> np_lst = [wp[node] for node in wp.get_level(5)]
             >>> viz = np.stack(np_lst).squeeze()
             >>> plt.imshow(np.abs(viz))
             >>> plt.show()

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -88,6 +88,10 @@ class WaveletPacket(BaseDict):
                 to use in the sparse matrix backend,
                 see :data:`ptwt.constants.OrthogonalizeMethod`.
                 Only used if `mode` equals 'boundary'. Defaults to 'qr'.
+            lazy_init (bool): Value is passed on to :func:`transform`.
+                If True, the packet tree is initialized lazily. This
+                allows for partial expansion of the wavelet packet tree.
+                Defaults to False.
 
         Example:
             >>> import torch, pywt, ptwt
@@ -135,6 +139,10 @@ class WaveletPacket(BaseDict):
             maxlevel (int, optional): The highest decomposition level to compute.
                 If None, the maximum level is determined from the input data shape.
                 Defaults to None.
+            lazy_init (bool): If True, the packet tree is initialized lazily.
+                This allows for partial expansion of the wavelet packet tree.
+                Otherwise, all packet coefficients up to the decomposition level
+                `maxlevel` are computed. Defaults to False.
         """
         self.data = {"": data}
         if maxlevel is None:
@@ -332,6 +340,10 @@ class WaveletPacket2D(BaseDict):
                 Only used if `mode` equals 'boundary'. Defaults to 'qr'.
             separable (bool): If true, a separable transform is performed,
                 i.e. each image axis is transformed separately. Defaults to False.
+            lazy_init (bool): Value is passed on to :func:`transform`.
+                If True, the packet tree is initialized lazily. This
+                allows for partial expansion of the wavelet packet tree.
+                Defaults to False.
 
         """
         self.wavelet = _as_wavelet(wavelet)
@@ -364,6 +376,10 @@ class WaveletPacket2D(BaseDict):
             maxlevel (int, optional): The highest decomposition level to compute.
                 If None, the maximum level is determined from the input data shape.
                 Defaults to None.
+            lazy_init (bool): If True, the packet tree is initialized lazily.
+                This allows for partial expansion of the wavelet packet tree.
+                Otherwise, all packet coefficients up to the decomposition level
+                `maxlevel` are computed. Defaults to False.
         """
         self.data = {"": data}
         if maxlevel is None:

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -157,6 +157,7 @@ class WaveletPacket(BaseDict):
                 tree nodes to initialize.
         """
         it = (self[key] for key in keys)
+        # exhaust iterator without storing all values
         collections.deque(it, maxlen=0)
 
     def reconstruct(self) -> WaveletPacket:
@@ -427,6 +428,7 @@ class WaveletPacket2D(BaseDict):
                 tree nodes to initialize.
         """
         it = (self[key] for key in keys)
+        # exhaust iterator without storing all values
         collections.deque(it, maxlen=0)
 
     def reconstruct(self) -> WaveletPacket2D:

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -179,9 +179,18 @@ class WaveletPacket(BaseDict):
 
         for level in reversed(range(self.maxlevel)):
             for node in self.get_level(level):
+                # check if any children is not available
+                # we need to check manually to avoid lazy init
+                def _test_key(key: str) -> None:
+                    if key not in self:
+                        raise KeyError(f"Key {key} not found")
+
+                for child in ["a", "d"]:
+                    _test_key(node + child)
+
                 data_a = self[node + "a"]
-                data_b = self[node + "d"]
-                rec = self._get_waverec(data_a.shape[-1])([data_a, data_b])
+                data_d = self[node + "d"]
+                rec = self._get_waverec(data_a.shape[-1])([data_a, data_d])
                 if level > 0:
                     if rec.shape[-1] != self[node].shape[-1]:
                         assert (
@@ -414,6 +423,15 @@ class WaveletPacket2D(BaseDict):
 
         for level in reversed(range(self.maxlevel)):
             for node in WaveletPacket2D.get_natural_order(level):
+                # check if any children is not available
+                # we need to check manually to avoid lazy init
+                def _test_key(key: str) -> None:
+                    if key not in self:
+                        raise KeyError(f"Key {key} not found")
+
+                for child in ["a", "h", "v", "d"]:
+                    _test_key(node + child)
+
                 data_a = self[node + "a"]
                 data_h = self[node + "h"]
                 data_v = self[node + "v"]

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -271,6 +271,15 @@ class WaveletPacket(BaseDict):
                 "cannot be accessed! This wavelet packet tree is initialized with "
                 f"maximum level {self.maxlevel}."
             )
+        elif key not in self:
+            if key == "":
+                raise ValueError(
+                    "The requested root of the packet tree cannot be accessed! "
+                    "The wavelet packet tree is not properly initialized. "
+                    "Run `transform` before accessing tree values."
+                )
+            # calculate data from parent
+            self._expand_node(key[:-1])
         return super().__getitem__(key)
 
 
@@ -529,6 +538,16 @@ class WaveletPacket2D(BaseDict):
                 "cannot be accessed! This wavelet packet tree is initialized with "
                 f"maximum level {self.maxlevel}."
             )
+        elif key not in self:
+            if key == "":
+                raise ValueError(
+                    "The requested root of the packet tree cannot be accessed! "
+                    "The wavelet packet tree is not properly initialized. "
+                    "Run `transform` before accessing tree values."
+                )
+            # calculate data from parent
+            self._expand_node(key[:-1])
+
         return super().__getitem__(key)
 
     @staticmethod

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -25,14 +25,13 @@ def _compare_trees1(
     transform_mode: bool = False,
     multiple_transforms: bool = False,
     axis: int = -1,
-    lazy_init: bool = False,
 ) -> None:
     data = np.random.rand(batch_size, length)
     data = data.swapaxes(axis, -1)
 
     if transform_mode:
         twp = WaveletPacket(None, wavelet_str, mode=ptwt_boundary, axis=axis).transform(
-            torch.from_numpy(data), maxlevel=max_lev, lazy_init=lazy_init
+            torch.from_numpy(data), maxlevel=max_lev
         )
     else:
         twp = WaveletPacket(
@@ -41,12 +40,11 @@ def _compare_trees1(
             mode=ptwt_boundary,
             maxlevel=max_lev,
             axis=axis,
-            lazy_init=lazy_init,
         )
 
     # if multiple_transform flag is set, recalculcate the packets
     if multiple_transforms:
-        twp.transform(torch.from_numpy(data), maxlevel=max_lev, lazy_init=lazy_init)
+        twp.transform(torch.from_numpy(data), maxlevel=max_lev)
 
     torch_res = torch.cat([twp[node] for node in twp.get_level(twp.maxlevel)], axis)
 
@@ -76,7 +74,6 @@ def _compare_trees2(
     transform_mode: bool = False,
     multiple_transforms: bool = False,
     axes: tuple[int, int] = (-2, -1),
-    lazy_init: bool = False,
 ) -> None:
     face = datasets.face()[:height, :width].astype(np.float64).mean(-1)
     data = torch.stack([torch.from_numpy(face)] * batch_size, 0)
@@ -103,7 +100,7 @@ def _compare_trees2(
     if transform_mode:
         ptwt_wp_tree = WaveletPacket2D(
             None, wavelet=wavelet_str, mode=ptwt_boundary, axes=axes
-        ).transform(data, maxlevel=max_lev, lazy_init=lazy_init)
+        ).transform(data, maxlevel=max_lev)
     else:
         ptwt_wp_tree = WaveletPacket2D(
             data,
@@ -111,12 +108,11 @@ def _compare_trees2(
             mode=ptwt_boundary,
             maxlevel=max_lev,
             axes=axes,
-            lazy_init=lazy_init,
         )
 
     # if multiple_transform flag is set, recalculcate the packets
     if multiple_transforms:
-        ptwt_wp_tree.transform(data, maxlevel=max_lev, lazy_init=lazy_init)
+        ptwt_wp_tree.transform(data, maxlevel=max_lev)
 
     packets_pt = torch.stack(
         [
@@ -140,7 +136,6 @@ def _compare_trees2(
 @pytest.mark.parametrize("transform_mode", [False, True])
 @pytest.mark.parametrize("multiple_transforms", [False, True])
 @pytest.mark.parametrize("axes", [(-2, -1), (-1, -2), (1, 2), (2, 0), (0, 2)])
-@pytest.mark.parametrize("lazy_init", [False, True])
 def test_2d_packets(
     max_lev: Optional[int],
     wavelet_str: str,
@@ -149,7 +144,6 @@ def test_2d_packets(
     transform_mode: bool,
     multiple_transforms: bool,
     axes: tuple[int, int],
-    lazy_init: bool,
 ) -> None:
     """Ensure pywt and ptwt produce equivalent wavelet 2d packet trees."""
     _compare_trees2(
@@ -161,7 +155,6 @@ def test_2d_packets(
         transform_mode=transform_mode,
         multiple_transforms=multiple_transforms,
         axes=axes,
-        lazy_init=lazy_init,
     )
 
 
@@ -171,14 +164,12 @@ def test_2d_packets(
 @pytest.mark.parametrize("transform_mode", [False, True])
 @pytest.mark.parametrize("multiple_transforms", [False, True])
 @pytest.mark.parametrize("axes", [(-2, -1), (-1, -2), (1, 2), (2, 0), (0, 2)])
-@pytest.mark.parametrize("lazy_init", [False, True])
 def test_boundary_matrix_packets2(
     max_lev: Optional[int],
     batch_size: int,
     transform_mode: bool,
     multiple_transforms: bool,
     axes: tuple[int, int],
-    lazy_init: bool,
 ) -> None:
     """Ensure the 2d - sparse matrix haar tree and pywt-tree are the same."""
     _compare_trees2(
@@ -190,7 +181,6 @@ def test_boundary_matrix_packets2(
         transform_mode=transform_mode,
         multiple_transforms=multiple_transforms,
         axes=axes,
-        lazy_init=lazy_init,
     )
 
 
@@ -204,7 +194,6 @@ def test_boundary_matrix_packets2(
 @pytest.mark.parametrize("transform_mode", [False, True])
 @pytest.mark.parametrize("multiple_transforms", [False, True])
 @pytest.mark.parametrize("axis", [0, -1])
-@pytest.mark.parametrize("lazy_init", [False, True])
 def test_1d_packets(
     max_lev: int,
     wavelet_str: str,
@@ -213,7 +202,6 @@ def test_1d_packets(
     transform_mode: bool,
     multiple_transforms: bool,
     axis: int,
-    lazy_init: bool,
 ) -> None:
     """Ensure pywt and ptwt produce equivalent wavelet 1d packet trees."""
     _compare_trees1(
@@ -225,7 +213,6 @@ def test_1d_packets(
         transform_mode=transform_mode,
         multiple_transforms=multiple_transforms,
         axis=axis,
-        lazy_init=lazy_init,
     )
 
 
@@ -233,12 +220,10 @@ def test_1d_packets(
 @pytest.mark.parametrize("max_lev", [1, 2, 3, 4, None])
 @pytest.mark.parametrize("transform_mode", [False, True])
 @pytest.mark.parametrize("multiple_transforms", [False, True])
-@pytest.mark.parametrize("lazy_init", [False, True])
 def test_boundary_matrix_packets1(
     max_lev: Optional[int],
     transform_mode: bool,
     multiple_transforms: bool,
-    lazy_init: bool,
 ) -> None:
     """Ensure the 2d - sparse matrix haar tree and pywt-tree are the same."""
     _compare_trees1(
@@ -248,7 +233,6 @@ def test_boundary_matrix_packets1(
         "boundary",
         transform_mode=transform_mode,
         multiple_transforms=multiple_transforms,
-        lazy_init=lazy_init,
     )
 
 
@@ -357,7 +341,6 @@ def test_partial_expansion_1d(wavelet_str: str, boundary: str) -> None:
         wavelet_str,
         mode=boundary,
         maxlevel=max_lev,
-        lazy_init=True,
     )
 
     # Full expansion of the wavelet packet tree
@@ -377,23 +360,10 @@ def test_partial_expansion_1d(wavelet_str: str, boundary: str) -> None:
 
     assert all(key in lazy_init_packet for key in partial_keys_1d)
 
-    eager_init_packet = WaveletPacket(
-        test_signal,
-        wavelet_str,
-        mode=boundary,
-        maxlevel=max_lev,
-        lazy_init=False,
-    )
+    # init on full keys
+    [lazy_init_packet[key] for key in full_keys]
 
-    assert all(key in eager_init_packet for key in full_keys)
-
-    diffs = [
-        ((lazy_init_packet[key] - eager_init_packet[key]) ** 2).sum()
-        for key in lazy_init_packet.keys()
-    ]
-    delta = torch.sum(torch.stack(diffs))
-
-    assert torch.isclose(delta, torch.tensor(0.0))
+    assert all(key in lazy_init_packet for key in full_keys)
 
 
 @pytest.mark.parametrize("wavelet_str", ["haar", "db4"])
@@ -412,7 +382,6 @@ def test_partial_expansion_2d(wavelet_str: str, boundary: str) -> None:
         wavelet_str,
         mode=boundary,
         maxlevel=max_lev,
-        lazy_init=True,
         separable=True,
     )
 
@@ -430,24 +399,10 @@ def test_partial_expansion_2d(wavelet_str: str, boundary: str) -> None:
 
     assert all(key in lazy_init_packet for key in partial_keys_2d)
 
-    eager_init_packet = WaveletPacket2D(
-        test_signal,
-        wavelet_str,
-        mode=boundary,
-        maxlevel=max_lev,
-        lazy_init=False,
-        separable=True,
-    )
+    # init on full keys
+    [lazy_init_packet[key] for key in full_keys]
 
-    assert all(key in eager_init_packet for key in full_keys)
-
-    diffs = [
-        ((lazy_init_packet[key] - eager_init_packet[key]) ** 2).sum()
-        for key in lazy_init_packet.keys()
-    ]
-    delta = torch.sum(torch.stack(diffs))
-
-    assert torch.isclose(delta, torch.tensor(0.0))
+    assert all(key in lazy_init_packet for key in full_keys)
 
 
 def test_packet_harbo_lvl3() -> None:
@@ -508,14 +463,12 @@ def test_access_errors_2d() -> None:
 @pytest.mark.parametrize("shape", [[1, 64, 63], [3, 64, 64], [1, 128]])
 @pytest.mark.parametrize("wavelet", ["db1", "db2", "sym4"])
 @pytest.mark.parametrize("axis", (1, -1))
-@pytest.mark.parametrize("lazy_init", [True, False])
 def test_inverse_packet_1d(
     level: int,
     base_key: str,
     shape: list[int],
     wavelet: str,
     axis: int,
-    lazy_init: bool,
 ) -> None:
     """Test the 1d reconstruction code."""
     signal = np.random.randn(*shape)
@@ -527,14 +480,12 @@ def test_inverse_packet_1d(
         mode=mode,
         maxlevel=level,
         axis=axis,
-        lazy_init=lazy_init,
     )
-    if lazy_init:
-        with pytest.raises(KeyError):
-            ptwp.reconstruct()
+    with pytest.raises(KeyError):
+        ptwp.reconstruct()
 
-        # lazy init
-        [ptwp[key] for key in ptwp.get_level(level)]
+    # lazy init
+    [ptwp[key] for key in ptwp.get_level(level)]
 
     wp[base_key * level].data *= 0
     ptwp[base_key * level] *= 0
@@ -549,14 +500,12 @@ def test_inverse_packet_1d(
 @pytest.mark.parametrize("size", [(32, 32, 32), (32, 32, 31, 64)])
 @pytest.mark.parametrize("wavelet", ["db1", "db2", "sym4"])
 @pytest.mark.parametrize("axes", [(-2, -1), (-1, -2), (1, 2), (2, 0), (0, 2)])
-@pytest.mark.parametrize("lazy_init", [True, False])
 def test_inverse_packet_2d(
     level: int,
     base_key: str,
     size: tuple[int, ...],
     wavelet: str,
     axes: tuple[int, int],
-    lazy_init: bool,
 ) -> None:
     """Test the 2d reconstruction code."""
     signal = np.random.randn(*size)
@@ -568,15 +517,13 @@ def test_inverse_packet_2d(
         mode=mode,
         maxlevel=level,
         axes=axes,
-        lazy_init=lazy_init,
     )
     wp[base_key * level].data *= 0
-    if lazy_init:
-        with pytest.raises(KeyError):
-            ptwp.reconstruct()
+    with pytest.raises(KeyError):
+        ptwp.reconstruct()
 
-        # lazy init
-        [ptwp[key] for key in ptwp.get_natural_order(level)]
+    # lazy init
+    [ptwp[key] for key in ptwp.get_natural_order(level)] 
 
     ptwp[base_key * level] *= 0
     wp.reconstruct(update=True)
@@ -616,8 +563,7 @@ def test_inverse_boundary_packet_2d() -> None:
 
 @pytest.mark.slow
 @pytest.mark.parametrize("axes", ((-2, -1), (1, 2), (2, 1)))
-@pytest.mark.parametrize("lazy_init", [True, False])
-def test_separable_conv_packets_2d(axes: tuple[int, int], lazy_init: bool) -> None:
+def test_separable_conv_packets_2d(axes: tuple[int, int]) -> None:
     """Ensure the 2d separable conv code is ok."""
     wavelet = "db2"
     signal = np.random.randn(1, 32, 32, 32)
@@ -628,13 +574,11 @@ def test_separable_conv_packets_2d(axes: tuple[int, int], lazy_init: bool) -> No
         maxlevel=2,
         axes=axes,
         separable=True,
-        lazy_init=lazy_init,
     )
-    if lazy_init:
-        with pytest.raises(KeyError):
-            ptwp.reconstruct()
+    with pytest.raises(KeyError):
+        ptwp.reconstruct()
 
-        # lazy init
-        [ptwp[key] for key in ptwp.get_natural_order(2)]
+    # lazy init
+    [ptwp[key] for key in ptwp.get_natural_order(2)]
     ptwp.reconstruct()
     assert np.allclose(signal, ptwp[""].data[:, :32, :32, :32])

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -535,10 +535,12 @@ def test_inverse_boundary_packet_1d() -> None:
     """Test the 2d boundary reconstruction code."""
     signal = np.random.randn(1, 16)
     wp = pywt.WaveletPacket(signal, "haar", mode="zero", maxlevel=2)
-    ptwp = WaveletPacket(torch.from_numpy(signal), "haar", mode="boundary", maxlevel=2)
     wp["aa"].data *= 0
-    ptwp["aa"].data *= 0
     wp.reconstruct(update=True)
+
+    ptwp = WaveletPacket(torch.from_numpy(signal), "haar", mode="boundary", maxlevel=2)
+    ptwp.initialize(["ad", "da", "dd"])
+    ptwp["aa"] *= 0
     ptwp.reconstruct()
     assert np.allclose(wp[""].data, ptwp[""].numpy()[:, :16])
 
@@ -550,14 +552,18 @@ def test_inverse_boundary_packet_2d() -> None:
     base_key = "h"
     wavelet = "haar"
     signal = np.random.randn(1, size[0], size[1])
+
     wp = pywt.WaveletPacket2D(signal, wavelet, mode="zero", maxlevel=level)
+    wp[base_key * level].data *= 0
+    wp.reconstruct(update=True)
+
     ptwp = WaveletPacket2D(
         torch.from_numpy(signal), wavelet, mode="boundary", maxlevel=level
     )
-    wp[base_key * level].data *= 0
-    ptwp[base_key * level].data *= 0
-    wp.reconstruct(update=True)
+    ptwp.initialize(WaveletPacket2D.get_natural_order(level))
+    ptwp[base_key * level] *= 0
     ptwp.reconstruct()
+
     assert np.allclose(wp[""].data, ptwp[""].numpy()[:, : size[0], : size[1]])
 
 

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -496,6 +496,13 @@ def test_inverse_packet_1d(
         axis=axis,
         lazy_init=lazy_init,
     )
+    if lazy_init:
+        with pytest.raises(KeyError):
+            ptwp.reconstruct()
+
+        # lazy init
+        [ptwp[key] for key in ptwp.get_level(level)]
+
     wp[base_key * level].data *= 0
     ptwp[base_key * level] *= 0
     wp.reconstruct(update=True)
@@ -531,6 +538,13 @@ def test_inverse_packet_2d(
         lazy_init=lazy_init,
     )
     wp[base_key * level].data *= 0
+    if lazy_init:
+        with pytest.raises(KeyError):
+            ptwp.reconstruct()
+
+        # lazy init
+        [ptwp[key] for key in ptwp.get_natural_order(level)]
+
     ptwp[base_key * level] *= 0
     wp.reconstruct(update=True)
     ptwp.reconstruct()
@@ -583,5 +597,11 @@ def test_separable_conv_packets_2d(axes: tuple[int, int], lazy_init: bool) -> No
         separable=True,
         lazy_init=lazy_init,
     )
+    if lazy_init:
+        with pytest.raises(KeyError):
+            ptwp.reconstruct()
+
+        # lazy init
+        [ptwp[key] for key in ptwp.get_natural_order(2)]
     ptwp.reconstruct()
     assert np.allclose(signal, ptwp[""].data[:, :32, :32, :32])

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -590,17 +590,15 @@ def test_separable_conv_packets_2d(axes: tuple[int, int]) -> None:
     assert np.allclose(signal, ptwp[""].data[:, :32, :32, :32])
 
 
-
 def test_partial_reconstruction() -> None:
-
+    """Reconstruct a cosine wave from packet filters."""
     signal = np.random.randn(1, 16)
     signal2 = np.cos(np.linspace(0, 2 * np.pi, 16))
-    ptwp = WaveletPacket(torch.from_numpy(signal), "haar",
-        mode="reflect", maxlevel=2)
+    ptwp = WaveletPacket(torch.from_numpy(signal), "haar", mode="reflect", maxlevel=2)
     ptwp.initialize(["aa", "ad", "da", "dd"])
-    
+
     ptwp2 = WaveletPacket(torch.from_numpy(signal2), "haar", mode="reflect", maxlevel=2)
-    
+
     # overwrite the first packet set.
     ptwp["aa"] = ptwp2["aa"]
     ptwp["ad"] = ptwp2["ad"]

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -588,3 +588,24 @@ def test_separable_conv_packets_2d(axes: tuple[int, int]) -> None:
     ptwp.initialize(ptwp.get_natural_order(2))
     ptwp.reconstruct()
     assert np.allclose(signal, ptwp[""].data[:, :32, :32, :32])
+
+
+
+def test_partial_reconstruction() -> None:
+
+    signal = np.random.randn(1, 16)
+    signal2 = np.cos(np.linspace(0, 2 * np.pi, 16))
+    ptwp = WaveletPacket(torch.from_numpy(signal), "haar",
+        mode="reflect", maxlevel=2)
+    ptwp.initialize(["aa", "ad", "da", "dd"])
+    
+    ptwp2 = WaveletPacket(torch.from_numpy(signal2), "haar", mode="reflect", maxlevel=2)
+    
+    # overwrite the first packet set.
+    ptwp["aa"] = ptwp2["aa"]
+    ptwp["ad"] = ptwp2["ad"]
+    ptwp["da"] = ptwp2["da"]
+    ptwp["dd"] = ptwp2["dd"]
+    ptwp.reconstruct()
+
+    assert np.allclose(signal2, ptwp[""].numpy()[:16])

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -360,7 +360,7 @@ def test_inverse_packet_1d(
         lazy_init=lazy_init,
     )
     wp[base_key * level].data *= 0
-    ptwp[base_key * level].data *= 0
+    ptwp[base_key * level] *= 0
     wp.reconstruct(update=True)
     ptwp.reconstruct()
     assert np.allclose(wp[""].data, ptwp[""].numpy()[..., : shape[-2], : shape[-1]])
@@ -394,7 +394,7 @@ def test_inverse_packet_2d(
         lazy_init=lazy_init,
     )
     wp[base_key * level].data *= 0
-    ptwp[base_key * level].data *= 0
+    ptwp[base_key * level] *= 0
     wp.reconstruct(update=True)
     ptwp.reconstruct()
     assert np.allclose(wp[""].data, ptwp[""].numpy()[: size[0], : size[1], : size[2]])

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -353,7 +353,7 @@ def test_partial_expansion_1d(wavelet_str: str, boundary: str) -> None:
         assert all(key in lazy_init_packet for key in partial_keys_1d)
 
     # init on partial keys
-    [lazy_init_packet[key] for key in partial_keys_1d]
+    lazy_init_packet.initialize(partial_keys_1d)
 
     with pytest.raises(AssertionError):
         assert all(key in lazy_init_packet for key in full_keys)
@@ -361,7 +361,7 @@ def test_partial_expansion_1d(wavelet_str: str, boundary: str) -> None:
     assert all(key in lazy_init_packet for key in partial_keys_1d)
 
     # init on full keys
-    [lazy_init_packet[key] for key in full_keys]
+    lazy_init_packet.initialize(full_keys)
 
     assert all(key in lazy_init_packet for key in full_keys)
 
@@ -392,7 +392,7 @@ def test_partial_expansion_2d(wavelet_str: str, boundary: str) -> None:
         assert all(key in lazy_init_packet for key in partial_keys_2d)
 
     # init on partial keys
-    [lazy_init_packet[key] for key in partial_keys_2d]
+    lazy_init_packet.initialize(partial_keys_2d)
 
     with pytest.raises(AssertionError):
         assert all(key in lazy_init_packet for key in full_keys)
@@ -400,7 +400,7 @@ def test_partial_expansion_2d(wavelet_str: str, boundary: str) -> None:
     assert all(key in lazy_init_packet for key in partial_keys_2d)
 
     # init on full keys
-    [lazy_init_packet[key] for key in full_keys]
+    lazy_init_packet.initialize(full_keys)
 
     assert all(key in lazy_init_packet for key in full_keys)
 
@@ -485,7 +485,7 @@ def test_inverse_packet_1d(
         ptwp.reconstruct()
 
     # lazy init
-    [ptwp[key] for key in ptwp.get_level(level)]
+    ptwp.initialize(ptwp.get_level(level))
 
     wp[base_key * level].data *= 0
     ptwp[base_key * level] *= 0
@@ -523,7 +523,7 @@ def test_inverse_packet_2d(
         ptwp.reconstruct()
 
     # lazy init
-    [ptwp[key] for key in ptwp.get_natural_order(level)] 
+    ptwp.initialize(ptwp.get_natural_order(level))
 
     ptwp[base_key * level] *= 0
     wp.reconstruct(update=True)
@@ -579,6 +579,6 @@ def test_separable_conv_packets_2d(axes: tuple[int, int]) -> None:
         ptwp.reconstruct()
 
     # lazy init
-    [ptwp[key] for key in ptwp.get_natural_order(2)]
+    ptwp.initialize(ptwp.get_natural_order(2))
     ptwp.reconstruct()
     assert np.allclose(signal, ptwp[""].data[:, :32, :32, :32])


### PR DESCRIPTION
Adds lazy initialization to wavelet packet objects and addresses #91.

Adds the option to lazy initialize a wavelet packet object by passing `lazy_init=True` to `__init__` or `transform`.
In the case, we avoid doing a expansion of the full packet tree.
If the user tries to access access a key not yet contained in the dict, we calculate the missing coeffs on the fly.

This allows for siginificant speedups if we are not interested in the full tree but only a subset of the nodes

The example of issue #69 is presented below:

```python
import torch, ptwt
max_lev = 4
shape = (512, 512)

test_signal = torch.randn(shape)
full_packet = ptwt.WaveletPacket2D(test_signal, "haar", maxlevel=max_lev)
partial_packet = ptwt.WaveletPacket2D(test_signal, "haar", maxlevel=max_lev, lazy_init=True)

# Full expansion of the wavelet packet tree
wp_keys = ptwt.WaveletPacket2D.get_natural_order(max_lev)

# Partial expansion
keys = ['aaaa', 'aaad', 'aaah', 'aaav', 'aad', 'aah', 'aava', 'aavd',
        'aavh', 'aavv', 'ad', 'ah', 'ava', 'avd', 'avh', 'avv', 'd', 'h',
        'vaa', 'vad', 'vah', 'vav', 'vd', 'vh', 'vv']

print("Partial expansion: keys contained?", all(key in partial_packet for key in keys))

print("Init...")
# lazy initialization
[partial_packet[key] for key in keys]

print("Partial expansion: keys contained?", all(key in partial_packet for key in keys))
print("Partial expansion: wp_keys contained?", all(key in partial_packet for key in wp_keys))

print()
diffs = [((partial_packet[key] - full_packet[key]) ** 2).sum() for key in keys]
print(f"Squared difference: {sum(diffs)=}")

print(f"# Partial keys: {len(partial_packet.keys())}")
print(f"# Full keys: {len(full_packet.keys())}")
```

which outputs
```
Partial expansion: keys contained? False
Init...
Partial expansion: keys contained? True
Partial expansion: wp_keys contained? False

Squared difference: sum(diffs)=tensor(0.)
# Partial keys: 33
# Full keys: 341
```