### PR TITLE
Allow specification of odd length boundary padding in MatrixWavedec

### DIFF
--- a/src/ptwt/_util.py
+++ b/src/ptwt/_util.py
@@ -93,8 +93,10 @@ def _as_wavelet(wavelet: Union[Wavelet, str]) -> Wavelet:
         return wavelet
 
 
-def _is_boundary_mode_supported(boundary_mode: Optional[OrthogonalizeMethod]) -> bool:
-    return boundary_mode in typing.get_args(OrthogonalizeMethod)
+def _is_orthogonalize_method_supported(
+    orthogonalization: Optional[OrthogonalizeMethod],
+) -> bool:
+    return orthogonalization in typing.get_args(OrthogonalizeMethod)
 
 
 def _is_dtype_supported(dtype: torch.dtype) -> bool:

--- a/src/ptwt/_util.py
+++ b/src/ptwt/_util.py
@@ -269,7 +269,7 @@ def _deprecated_alias(
 
     Use as follows::
 
-        @deprecated_alias(old_arg='new_arg')
+        @_deprecated_alias(old_arg='new_arg')
         def myfunc(new_arg):
             ...
 

--- a/src/ptwt/conv_transform.py
+++ b/src/ptwt/conv_transform.py
@@ -135,6 +135,7 @@ def _fwt_pad(
     wavelet: Union[Wavelet, str],
     *,
     mode: Optional[BoundaryMode] = None,
+    padding: Optional[tuple[int, int]] = None,
 ) -> torch.Tensor:
     """Pad the input signal to make the fwt matrix work.
 
@@ -144,21 +145,25 @@ def _fwt_pad(
         data (torch.Tensor): Input data ``[batch_size, 1, time]``
         wavelet (Wavelet or str): A pywt wavelet compatible object or
             the name of a pywt wavelet.
-        mode :
-            The desired padding mode for extending the signal along the edges.
+        mode: The desired padding mode for extending the signal along the edges.
             Defaults to "reflect". See :data:`ptwt.constants.BoundaryMode`.
+        padding (tuple[int, int], optional): A tuple (padl, padr) with the
+            number of padded values on the left and right side of the last
+            axes of `data`. If None, the padding values are computed based
+            on the signal shape and the wavelet length. Defaults to None.
 
     Returns:
         A PyTorch tensor with the padded input data
     """
-    wavelet = _as_wavelet(wavelet)
-
     # convert pywt to pytorch convention.
     if mode is None:
         mode = "reflect"
     pytorch_mode = _translate_boundary_strings(mode)
 
-    padr, padl = _get_pad(data.shape[-1], _get_len(wavelet))
+    if padding is None:
+        padr, padl = _get_pad(data.shape[-1], _get_len(wavelet))
+    else:
+        padl, padr = padding
     if pytorch_mode == "symmetric":
         data_pad = _pad_symmetric(data, [(padl, padr)])
     else:

--- a/src/ptwt/conv_transform_2.py
+++ b/src/ptwt/conv_transform_2.py
@@ -65,6 +65,7 @@ def _fwt_pad2(
     wavelet: Union[Wavelet, str],
     *,
     mode: Optional[BoundaryMode] = None,
+    padding: Optional[tuple[int, int, int, int]] = None,
 ) -> torch.Tensor:
     """Pad data for the 2d FWT.
 
@@ -76,9 +77,13 @@ def _fwt_pad2(
             the name of a pywt wavelet.
             Refer to the output from ``pywt.wavelist(kind='discrete')``
             for possible choices.
-        mode :
-            The desired padding mode for extending the signal along the edges.
+        mode: The desired padding mode for extending the signal along the edges.
             Defaults to "reflect". See :data:`ptwt.constants.BoundaryMode`.
+        padding (tuple[int, int, int, int], optional): A tuple
+            (padl, padr, padt, padb) with the number of padded values
+            on the left, right, top and bottom side of the last two
+            axes of `data`. If None, the padding values are computed based
+            on the signal shape and the wavelet length. Defaults to None.
 
     Returns:
         The padded output tensor.
@@ -87,9 +92,12 @@ def _fwt_pad2(
     if mode is None:
         mode = "reflect"
     pytorch_mode = _translate_boundary_strings(mode)
-    wavelet = _as_wavelet(wavelet)
-    padb, padt = _get_pad(data.shape[-2], _get_len(wavelet))
-    padr, padl = _get_pad(data.shape[-1], _get_len(wavelet))
+
+    if padding is None:
+        padb, padt = _get_pad(data.shape[-2], _get_len(wavelet))
+        padr, padl = _get_pad(data.shape[-1], _get_len(wavelet))
+    else:
+        padl, padr, padt, padb = padding
     if pytorch_mode == "symmetric":
         data_pad = _pad_symmetric(data, [(padt, padb), (padl, padr)])
     else:

--- a/src/ptwt/matmul_transform.py
+++ b/src/ptwt/matmul_transform.py
@@ -217,9 +217,10 @@ class MatrixWavedec(BaseMatrixWaveDec):
             The argument `boundary` has been renamed to `orthogonalization`.
 
         Raises:
-            NotImplementedError: If the selected `boundary` mode is not supported.
+            NotImplementedError: If the selected `orthogonalization` mode
+                is not supported.
             ValueError: If the wavelet filters have different lengths or
-                        if axis is not an integer.
+                if axis is not an integer.
         """
         self.wavelet = _as_wavelet(wavelet)
         self.level = level
@@ -518,7 +519,8 @@ class MatrixWaverec(object):
             The argument `boundary` has been renamed to `orthogonalization`.
 
         Raises:
-            NotImplementedError: If the selected `boundary` mode is not supported.
+            NotImplementedError: If the selected `orthogonalization` mode
+                is not supported.
             ValueError: If the wavelet filters have different lengths or if
                         axis is not an integer.
         """

--- a/src/ptwt/matmul_transform.py
+++ b/src/ptwt/matmul_transform.py
@@ -18,8 +18,8 @@ from ._util import (
     Wavelet,
     _as_wavelet,
     _deprecated_alias,
-    _is_boundary_mode_supported,
     _is_dtype_supported,
+    _is_orthogonalize_method_supported,
     _unfold_axes,
 )
 from .constants import BoundaryMode, OrthogonalizeMethod
@@ -237,7 +237,7 @@ class MatrixWavedec(BaseMatrixWaveDec):
         self.padded = False
         self.size_list: list[int] = []
 
-        if not _is_boundary_mode_supported(self.orthogonalization):
+        if not _is_orthogonalize_method_supported(self.orthogonalization):
             raise NotImplementedError
 
         if self.wavelet.dec_len != self.wavelet.rec_len:
@@ -534,7 +534,7 @@ class MatrixWaverec(object):
         self.input_length: Optional[int] = None
         self.padded = False
 
-        if not _is_boundary_mode_supported(self.orthogonalization):
+        if not _is_orthogonalize_method_supported(self.orthogonalization):
             raise NotImplementedError
 
         if self.wavelet.dec_len != self.wavelet.rec_len:

--- a/src/ptwt/matmul_transform.py
+++ b/src/ptwt/matmul_transform.py
@@ -183,13 +183,13 @@ class MatrixWavedec(BaseMatrixWaveDec):
         >>> coefficients = matrix_wavedec(data_torch)
     """
 
-    @_deprecated_alias(boundary="boundary_orthogonalization")
+    @_deprecated_alias(boundary="orthogonalization")
     def __init__(
         self,
         wavelet: Union[Wavelet, str],
         level: Optional[int] = None,
         axis: Optional[int] = -1,
-        boundary_orthogonalization: OrthogonalizeMethod = "qr",
+        orthogonalization: OrthogonalizeMethod = "qr",
         odd_coeff_padding_mode: BoundaryMode = "zero",
     ) -> None:
         """Create a sparse matrix fast wavelet transform object.
@@ -204,7 +204,7 @@ class MatrixWavedec(BaseMatrixWaveDec):
                 None.
             axis (int, optional): The axis we would like to transform.
                 Defaults to -1.
-            boundary_orthogonalization: The method used to orthogonalize
+            orthogonalization: The method used to orthogonalize
                 boundary filters, see :data:`ptwt.constants.OrthogonalizeMethod`.
                 Defaults to 'qr'.
             odd_coeff_padding_mode: The constructed FWT matrices require inputs
@@ -214,7 +214,7 @@ class MatrixWavedec(BaseMatrixWaveDec):
                 Defaults to 'zero'.
 
         .. versionchanged:: 1.10
-            The argument `boundary` has been renamed to `boundary_orthogonalization`.
+            The argument `boundary` has been renamed to `orthogonalization`.
 
         Raises:
             NotImplementedError: If the selected `boundary` mode is not supported.
@@ -224,7 +224,7 @@ class MatrixWavedec(BaseMatrixWaveDec):
         self.wavelet = _as_wavelet(wavelet)
         self.level = level
         self.odd_coeff_padding_mode = odd_coeff_padding_mode
-        self.boundary_orthogonalization = boundary_orthogonalization
+        self.orthogonalization = orthogonalization
 
         if isinstance(axis, int):
             self.axis = axis
@@ -237,7 +237,7 @@ class MatrixWavedec(BaseMatrixWaveDec):
         self.padded = False
         self.size_list: list[int] = []
 
-        if not _is_boundary_mode_supported(self.boundary_orthogonalization):
+        if not _is_boundary_mode_supported(self.orthogonalization):
             raise NotImplementedError
 
         if self.wavelet.dec_len != self.wavelet.rec_len:
@@ -317,7 +317,7 @@ class MatrixWavedec(BaseMatrixWaveDec):
             an = construct_boundary_a(
                 self.wavelet,
                 curr_length,
-                boundary_orthogonalization=self.boundary_orthogonalization,
+                orthogonalization=self.orthogonalization,
                 device=device,
                 dtype=dtype,
             )
@@ -408,12 +408,12 @@ class MatrixWavedec(BaseMatrixWaveDec):
         return result_list
 
 
-@_deprecated_alias(boundary="boundary_orthogonalization")
+@_deprecated_alias(boundary="orthogonalization")
 def construct_boundary_a(
     wavelet: Union[Wavelet, str],
     length: int,
     device: Union[torch.device, str] = "cpu",
-    boundary_orthogonalization: OrthogonalizeMethod = "qr",
+    orthogonalization: OrthogonalizeMethod = "qr",
     dtype: torch.dtype = torch.float64,
 ) -> torch.Tensor:
     """Construct a boundary-wavelet filter 1d-analysis matrix.
@@ -422,7 +422,7 @@ def construct_boundary_a(
         wavelet (Wavelet or str): A pywt wavelet compatible object or
             the name of a pywt wavelet.
         length (int): The number of entries in the input signal.
-        boundary_orthogonalization: The method used to orthogonalize
+        orthogonalization: The method used to orthogonalize
             boundary filters, see :data:`ptwt.constants.OrthogonalizeMethod`.
             Defaults to 'qr'.
         device: Where to place the matrix. Choose cpu or cuda.
@@ -430,23 +430,23 @@ def construct_boundary_a(
         dtype: Choose float32 or float64.
 
     .. versionchanged:: 1.10
-        The argument `boundary` has been renamed to `boundary_orthogonalization`.
+        The argument `boundary` has been renamed to `orthogonalization`.
 
     Returns:
         The sparse analysis matrix.
     """
     wavelet = _as_wavelet(wavelet)
     a_full = _construct_a(wavelet, length, dtype=dtype, device=device)
-    a_orth = orthogonalize(a_full, wavelet.dec_len, method=boundary_orthogonalization)
+    a_orth = orthogonalize(a_full, wavelet.dec_len, method=orthogonalization)
     return a_orth
 
 
-@_deprecated_alias(boundary="boundary_orthogonalization")
+@_deprecated_alias(boundary="orthogonalization")
 def construct_boundary_s(
     wavelet: Union[Wavelet, str],
     length: int,
     device: Union[torch.device, str] = "cpu",
-    boundary_orthogonalization: OrthogonalizeMethod = "qr",
+    orthogonalization: OrthogonalizeMethod = "qr",
     dtype: torch.dtype = torch.float64,
 ) -> torch.Tensor:
     """Construct a boundary-wavelet filter 1d-synthesis matarix.
@@ -457,14 +457,14 @@ def construct_boundary_s(
         length (int): The number of entries in the input signal.
         device (torch.device): Where to place the matrix.
             Choose cpu or cuda. Defaults to cpu.
-        boundary_orthogonalization: The method used to orthogonalize
+        orthogonalization: The method used to orthogonalize
             boundary filters, see :data:`ptwt.constants.OrthogonalizeMethod`.
             Defaults to 'qr'.
         dtype: Choose torch.float32 or torch.float64.
             Defaults to torch.float64.
 
     .. versionchanged:: 1.10
-        The argument `boundary` has been renamed to `boundary_orthogonalization`.
+        The argument `boundary` has been renamed to `orthogonalization`.
 
     Returns:
         The sparse synthesis matrix.
@@ -472,7 +472,7 @@ def construct_boundary_s(
     wavelet = _as_wavelet(wavelet)
     s_full = _construct_s(wavelet, length, dtype=dtype, device=device)
     s_orth = orthogonalize(
-        s_full.transpose(1, 0), wavelet.rec_len, method=boundary_orthogonalization
+        s_full.transpose(1, 0), wavelet.rec_len, method=orthogonalization
     )
     return s_orth.transpose(1, 0)
 
@@ -494,12 +494,12 @@ class MatrixWaverec(object):
         >>> reconstruction = matrix_waverec(coefficients)
     """
 
-    @_deprecated_alias(boundary="boundary_orthogonalization")
+    @_deprecated_alias(boundary="orthogonalization")
     def __init__(
         self,
         wavelet: Union[Wavelet, str],
         axis: int = -1,
-        boundary_orthogonalization: OrthogonalizeMethod = "qr",
+        orthogonalization: OrthogonalizeMethod = "qr",
     ) -> None:
         """Create the inverse matrix-based fast wavelet transformation.
 
@@ -510,12 +510,12 @@ class MatrixWaverec(object):
                 for possible choices.
             axis (int): The axis transformed by the original decomposition
                 defaults to -1 or the last axis.
-            boundary_orthogonalization: The method used to orthogonalize
+            orthogonalization: The method used to orthogonalize
                 boundary filters, see :data:`ptwt.constants.OrthogonalizeMethod`.
                 Defaults to 'qr'.
 
         .. versionchanged:: 1.10
-            The argument `boundary` has been renamed to `boundary_orthogonalization`.
+            The argument `boundary` has been renamed to `orthogonalization`.
 
         Raises:
             NotImplementedError: If the selected `boundary` mode is not supported.
@@ -523,7 +523,7 @@ class MatrixWaverec(object):
                         axis is not an integer.
         """
         self.wavelet = _as_wavelet(wavelet)
-        self.boundary_orthogonalization = boundary_orthogonalization
+        self.orthogonalization = orthogonalization
         if isinstance(axis, int):
             self.axis = axis
         else:
@@ -534,7 +534,7 @@ class MatrixWaverec(object):
         self.input_length: Optional[int] = None
         self.padded = False
 
-        if not _is_boundary_mode_supported(self.boundary_orthogonalization):
+        if not _is_boundary_mode_supported(self.orthogonalization):
             raise NotImplementedError
 
         if self.wavelet.dec_len != self.wavelet.rec_len:
@@ -614,7 +614,7 @@ class MatrixWaverec(object):
             sn = construct_boundary_s(
                 self.wavelet,
                 curr_length,
-                boundary_orthogonalization=self.boundary_orthogonalization,
+                orthogonalization=self.orthogonalization,
                 device=device,
                 dtype=dtype,
             )

--- a/src/ptwt/matmul_transform.py
+++ b/src/ptwt/matmul_transform.py
@@ -213,6 +213,9 @@ class MatrixWavedec(BaseMatrixWaveDec):
                 see :data:`ptwt.constants.BoundaryMode`.
                 Defaults to 'zero'.
 
+        .. versionchanged:: 1.10
+            The argument `boundary` has been renamed to `boundary_orthogonalization`.
+
         Raises:
             NotImplementedError: If the selected `boundary` mode is not supported.
             ValueError: If the wavelet filters have different lengths or
@@ -426,6 +429,9 @@ def construct_boundary_a(
             Defaults to cpu.
         dtype: Choose float32 or float64.
 
+    .. versionchanged:: 1.10
+        The argument `boundary` has been renamed to `boundary_orthogonalization`.
+
     Returns:
         The sparse analysis matrix.
     """
@@ -456,6 +462,9 @@ def construct_boundary_s(
             Defaults to 'qr'.
         dtype: Choose torch.float32 or torch.float64.
             Defaults to torch.float64.
+
+    .. versionchanged:: 1.10
+        The argument `boundary` has been renamed to `boundary_orthogonalization`.
 
     Returns:
         The sparse synthesis matrix.
@@ -504,6 +513,9 @@ class MatrixWaverec(object):
             boundary_orthogonalization: The method used to orthogonalize
                 boundary filters, see :data:`ptwt.constants.OrthogonalizeMethod`.
                 Defaults to 'qr'.
+
+        .. versionchanged:: 1.10
+            The argument `boundary` has been renamed to `boundary_orthogonalization`.
 
         Raises:
             NotImplementedError: If the selected `boundary` mode is not supported.

--- a/src/ptwt/matmul_transform_2.py
+++ b/src/ptwt/matmul_transform_2.py
@@ -18,8 +18,8 @@ from ._util import (
     _check_axes_argument,
     _check_if_tensor,
     _deprecated_alias,
-    _is_boundary_mode_supported,
     _is_dtype_supported,
+    _is_orthogonalize_method_supported,
     _map_result,
     _swap_axes,
     _undo_swap_axes,
@@ -331,7 +331,7 @@ class MatrixWavedec2(BaseMatrixWaveDec):
         self.pad_list: list[tuple[bool, bool]] = []
         self.padded = False
 
-        if not _is_boundary_mode_supported(self.orthogonalization):
+        if not _is_orthogonalize_method_supported(self.orthogonalization):
             raise NotImplementedError
 
         if self.wavelet.dec_len != self.wavelet.rec_len:
@@ -640,7 +640,7 @@ class MatrixWaverec2(object):
 
         self.padded = False
 
-        if not _is_boundary_mode_supported(self.orthogonalization):
+        if not _is_orthogonalize_method_supported(self.orthogonalization):
             raise NotImplementedError
 
         if self.wavelet.dec_len != self.wavelet.rec_len:

--- a/src/ptwt/matmul_transform_2.py
+++ b/src/ptwt/matmul_transform_2.py
@@ -149,13 +149,13 @@ def _construct_s_2(
     return transpose_synthesis
 
 
-@_deprecated_alias(boundary="boundary_orthogonalization")
+@_deprecated_alias(boundary="orthogonalization")
 def construct_boundary_a2(
     wavelet: Union[Wavelet, str],
     height: int,
     width: int,
     device: Union[torch.device, str],
-    boundary_orthogonalization: OrthogonalizeMethod = "qr",
+    orthogonalization: OrthogonalizeMethod = "qr",
     dtype: torch.dtype = torch.float64,
 ) -> torch.Tensor:
     """Construct a boundary fwt matrix for the input wavelet.
@@ -169,14 +169,14 @@ def construct_boundary_a2(
             Should be divisible by two.
         device (torch.device): Where to place the matrix. Either on
             the CPU or GPU.
-        boundary_orthogonalization: The method used to orthogonalize
+        orthogonalization: The method used to orthogonalize
             boundary filters, see :data:`ptwt.constants.OrthogonalizeMethod`.
             Defaults to 'qr'.
         dtype (torch.dtype, optional): The desired data type for the matrix.
             Defaults to torch.float64.
 
     .. versionchanged:: 1.10
-        The argument `boundary` has been renamed to `boundary_orthogonalization`.
+        The argument `boundary` has been renamed to `orthogonalization`.
 
     Returns:
         A sparse fwt matrix, with orthogonalized boundary wavelets.
@@ -184,19 +184,19 @@ def construct_boundary_a2(
     wavelet = _as_wavelet(wavelet)
     a = _construct_a_2(wavelet, height, width, device, dtype=dtype, mode="sameshift")
     orth_a = orthogonalize(
-        a, wavelet.dec_len**2, method=boundary_orthogonalization
+        a, wavelet.dec_len**2, method=orthogonalization
     )  # noqa: BLK100
     return orth_a
 
 
-@_deprecated_alias(boundary="boundary_orthogonalization")
+@_deprecated_alias(boundary="orthogonalization")
 def construct_boundary_s2(
     wavelet: Union[Wavelet, str],
     height: int,
     width: int,
     device: Union[torch.device, str],
     *,
-    boundary_orthogonalization: OrthogonalizeMethod = "qr",
+    orthogonalization: OrthogonalizeMethod = "qr",
     dtype: torch.dtype = torch.float64,
 ) -> torch.Tensor:
     """Construct a 2d-fwt matrix, with boundary wavelets.
@@ -207,7 +207,7 @@ def construct_boundary_s2(
         height (int): The original height of the input matrix.
         width (int): The width of the original input matrix.
         device (torch.device): Choose CPU or GPU.
-        boundary_orthogonalization: The method used to orthogonalize
+        orthogonalization: The method used to orthogonalize
             boundary filters, see :data:`ptwt.constants.OrthogonalizeMethod`.
             Defaults to 'qr'.
         dtype (torch.dtype, optional): The data type of the
@@ -215,7 +215,7 @@ def construct_boundary_s2(
             Defaults to torch.float64.
 
     .. versionchanged:: 1.10
-        The argument `boundary` has been renamed to `boundary_orthogonalization`.
+        The argument `boundary` has been renamed to `orthogonalization`.
 
     Returns:
         The synthesis matrix, used to compute the inverse fast wavelet transform.
@@ -225,7 +225,7 @@ def construct_boundary_s2(
     orth_s = orthogonalize(
         s.transpose(1, 0),
         wavelet.rec_len**2,
-        method=boundary_orthogonalization,  # noqa: BLK100
+        method=orthogonalization,  # noqa: BLK100
     ).transpose(1, 0)
     return orth_s
 
@@ -271,13 +271,13 @@ class MatrixWavedec2(BaseMatrixWaveDec):
         >>> mat_coeff = matrixfwt(pt_face)
     """
 
-    @_deprecated_alias(boundary="boundary_orthogonalization")
+    @_deprecated_alias(boundary="orthogonalization")
     def __init__(
         self,
         wavelet: Union[Wavelet, str],
         level: Optional[int] = None,
         axes: tuple[int, int] = (-2, -1),
-        boundary_orthogonalization: OrthogonalizeMethod = "qr",
+        orthogonalization: OrthogonalizeMethod = "qr",
         separable: bool = True,
         odd_coeff_padding_mode: BoundaryMode = "zero",
     ):
@@ -293,7 +293,7 @@ class MatrixWavedec2(BaseMatrixWaveDec):
                 None.
             axes (int, int): A tuple with the axes to transform.
                 Defaults to (-2, -1).
-            boundary_orthogonalization: The method used to orthogonalize
+            orthogonalization: The method used to orthogonalize
                 boundary filters, see :data:`ptwt.constants.OrthogonalizeMethod`.
                 Defaults to 'qr'.
             separable (bool): If this flag is set, a separable transformation
@@ -308,7 +308,7 @@ class MatrixWavedec2(BaseMatrixWaveDec):
                 Defaults to 'zero'.
 
         .. versionchanged:: 1.10
-            The argument `boundary` has been renamed to `boundary_orthogonalization`.
+            The argument `boundary` has been renamed to `orthogonalization`.
 
         Raises:
             NotImplementedError: If the selected `boundary` mode is not supported.
@@ -321,7 +321,7 @@ class MatrixWavedec2(BaseMatrixWaveDec):
             _check_axes_argument(list(axes))
             self.axes = tuple(axes)
         self.level = level
-        self.boundary_orthogonalization = boundary_orthogonalization
+        self.orthogonalization = orthogonalization
         self.odd_coeff_padding_mode = odd_coeff_padding_mode
         self.separable = separable
         self.input_signal_shape: Optional[tuple[int, int]] = None
@@ -331,7 +331,7 @@ class MatrixWavedec2(BaseMatrixWaveDec):
         self.pad_list: list[tuple[bool, bool]] = []
         self.padded = False
 
-        if not _is_boundary_mode_supported(self.boundary_orthogonalization):
+        if not _is_boundary_mode_supported(self.orthogonalization):
             raise NotImplementedError
 
         if self.wavelet.dec_len != self.wavelet.rec_len:
@@ -414,14 +414,14 @@ class MatrixWavedec2(BaseMatrixWaveDec):
                 analysis_matrix_rows = construct_boundary_a(
                     wavelet=self.wavelet,
                     length=current_height,
-                    boundary_orthogonalization=self.boundary_orthogonalization,
+                    orthogonalization=self.orthogonalization,
                     device=device,
                     dtype=dtype,
                 )
                 analysis_matrix_cols = construct_boundary_a(
                     wavelet=self.wavelet,
                     length=current_width,
-                    boundary_orthogonalization=self.boundary_orthogonalization,
+                    orthogonalization=self.orthogonalization,
                     device=device,
                     dtype=dtype,
                 )
@@ -433,7 +433,7 @@ class MatrixWavedec2(BaseMatrixWaveDec):
                     wavelet=self.wavelet,
                     height=current_height,
                     width=current_width,
-                    boundary_orthogonalization=self.boundary_orthogonalization,
+                    orthogonalization=self.orthogonalization,
                     device=device,
                     dtype=dtype,
                 )
@@ -588,12 +588,12 @@ class MatrixWaverec2(object):
         >>> reconstruction = matrixifwt(mat_coeff)
     """
 
-    @_deprecated_alias(boundary="boundary_orthogonalization")
+    @_deprecated_alias(boundary="orthogonalization")
     def __init__(
         self,
         wavelet: Union[Wavelet, str],
         axes: tuple[int, int] = (-2, -1),
-        boundary_orthogonalization: OrthogonalizeMethod = "qr",
+        orthogonalization: OrthogonalizeMethod = "qr",
         separable: bool = True,
     ):
         """Create the inverse matrix-based fast wavelet transformation.
@@ -605,7 +605,7 @@ class MatrixWaverec2(object):
                 for possible choices.
             axes (int, int): The axes transformed by waverec2.
                 Defaults to (-2, -1).
-            boundary_orthogonalization: The method used to orthogonalize
+            orthogonalization: The method used to orthogonalize
                 boundary filters, see :data:`ptwt.constants.OrthogonalizeMethod`.
                 Defaults to 'qr'.
             separable (bool): If this flag is set, a separable transformation
@@ -616,14 +616,14 @@ class MatrixWaverec2(object):
                 Defaults to True.
 
         .. versionchanged:: 1.10
-            The argument `boundary` has been renamed to `boundary_orthogonalization`.
+            The argument `boundary` has been renamed to `orthogonalization`.
 
         Raises:
             NotImplementedError: If the selected `boundary` mode is not supported.
             ValueError: If the wavelet filters have different lengths.
         """
         self.wavelet = _as_wavelet(wavelet)
-        self.boundary_orthogonalization = boundary_orthogonalization
+        self.orthogonalization = orthogonalization
         self.separable = separable
 
         if len(axes) != 2:
@@ -640,7 +640,7 @@ class MatrixWaverec2(object):
 
         self.padded = False
 
-        if not _is_boundary_mode_supported(self.boundary_orthogonalization):
+        if not _is_boundary_mode_supported(self.orthogonalization):
             raise NotImplementedError
 
         if self.wavelet.dec_len != self.wavelet.rec_len:
@@ -717,14 +717,14 @@ class MatrixWaverec2(object):
                 synthesis_matrix_rows = construct_boundary_s(
                     wavelet=self.wavelet,
                     length=current_height,
-                    boundary_orthogonalization=self.boundary_orthogonalization,
+                    orthogonalization=self.orthogonalization,
                     device=device,
                     dtype=dtype,
                 )
                 synthesis_matrix_cols = construct_boundary_s(
                     wavelet=self.wavelet,
                     length=current_width,
-                    boundary_orthogonalization=self.boundary_orthogonalization,
+                    orthogonalization=self.orthogonalization,
                     device=device,
                     dtype=dtype,
                 )
@@ -736,7 +736,7 @@ class MatrixWaverec2(object):
                     self.wavelet,
                     current_height,
                     current_width,
-                    boundary_orthogonalization=self.boundary_orthogonalization,
+                    orthogonalization=self.orthogonalization,
                     device=device,
                     dtype=dtype,
                 )

--- a/src/ptwt/matmul_transform_2.py
+++ b/src/ptwt/matmul_transform_2.py
@@ -175,6 +175,9 @@ def construct_boundary_a2(
         dtype (torch.dtype, optional): The desired data type for the matrix.
             Defaults to torch.float64.
 
+    .. versionchanged:: 1.10
+        The argument `boundary` has been renamed to `boundary_orthogonalization`.
+
     Returns:
         A sparse fwt matrix, with orthogonalized boundary wavelets.
     """
@@ -210,6 +213,9 @@ def construct_boundary_s2(
         dtype (torch.dtype, optional): The data type of the
             sparse matrix, choose float32 or 64.
             Defaults to torch.float64.
+
+    .. versionchanged:: 1.10
+        The argument `boundary` has been renamed to `boundary_orthogonalization`.
 
     Returns:
         The synthesis matrix, used to compute the inverse fast wavelet transform.
@@ -300,6 +306,9 @@ class MatrixWavedec2(BaseMatrixWaveDec):
                 are padded to an even length using this mode,
                 see :data:`ptwt.constants.BoundaryMode`.
                 Defaults to 'zero'.
+
+        .. versionchanged:: 1.10
+            The argument `boundary` has been renamed to `boundary_orthogonalization`.
 
         Raises:
             NotImplementedError: If the selected `boundary` mode is not supported.
@@ -605,6 +614,9 @@ class MatrixWaverec2(object):
                 size part of the matrices must be orthogonalized.
                 For invertibility, the analysis and synthesis values must be identical!
                 Defaults to True.
+
+        .. versionchanged:: 1.10
+            The argument `boundary` has been renamed to `boundary_orthogonalization`.
 
         Raises:
             NotImplementedError: If the selected `boundary` mode is not supported.

--- a/src/ptwt/matmul_transform_2.py
+++ b/src/ptwt/matmul_transform_2.py
@@ -311,7 +311,8 @@ class MatrixWavedec2(BaseMatrixWaveDec):
             The argument `boundary` has been renamed to `orthogonalization`.
 
         Raises:
-            NotImplementedError: If the selected `boundary` mode is not supported.
+            NotImplementedError: If the selected `orthogonalization` mode
+                is not supported.
             ValueError: If the wavelet filters have different lengths.
         """
         self.wavelet = _as_wavelet(wavelet)
@@ -619,7 +620,8 @@ class MatrixWaverec2(object):
             The argument `boundary` has been renamed to `orthogonalization`.
 
         Raises:
-            NotImplementedError: If the selected `boundary` mode is not supported.
+            NotImplementedError: If the selected `orthogonalization` mode
+                is not supported.
             ValueError: If the wavelet filters have different lengths.
         """
         self.wavelet = _as_wavelet(wavelet)

--- a/src/ptwt/matmul_transform_3.py
+++ b/src/ptwt/matmul_transform_3.py
@@ -316,7 +316,8 @@ class MatrixWaverec3(object):
             The argument `boundary` has been renamed to `orthogonalization`.
 
         Raises:
-            NotImplementedError: If the selected `boundary` mode is not supported.
+            NotImplementedError: If the selected `orthogonalization` mode
+                is not supported.
             ValueError: If the wavelet filters have different lengths.
         """
         self.wavelet = _as_wavelet(wavelet)

--- a/src/ptwt/matmul_transform_3.py
+++ b/src/ptwt/matmul_transform_3.py
@@ -16,8 +16,8 @@ from ._util import (
     _check_if_tensor,
     _deprecated_alias,
     _fold_axes,
-    _is_boundary_mode_supported,
     _is_dtype_supported,
+    _is_orthogonalize_method_supported,
     _map_result,
     _swap_axes,
     _undo_swap_axes,
@@ -107,7 +107,7 @@ class MatrixWavedec3(object):
         self.input_signal_shape: Optional[tuple[int, int, int]] = None
         self.fwt_matrix_list: list[list[torch.Tensor]] = []
 
-        if not _is_boundary_mode_supported(self.orthogonalization):
+        if not _is_orthogonalize_method_supported(self.orthogonalization):
             raise NotImplementedError
         if self.wavelet.dec_len != self.wavelet.rec_len:
             raise ValueError("All filters must have the same length")
@@ -330,7 +330,7 @@ class MatrixWaverec3(object):
         self.input_signal_shape: Optional[tuple[int, int, int]] = None
         self.level: Optional[int] = None
 
-        if not _is_boundary_mode_supported(self.orthogonalization):
+        if not _is_orthogonalize_method_supported(self.orthogonalization):
             raise NotImplementedError
 
         if self.wavelet.dec_len != self.wavelet.rec_len:

--- a/src/ptwt/matmul_transform_3.py
+++ b/src/ptwt/matmul_transform_3.py
@@ -86,6 +86,9 @@ class MatrixWavedec3(object):
                 see :data:`ptwt.constants.BoundaryMode`.
                 Defaults to 'zero'.
 
+        .. versionchanged:: 1.10
+            The argument `boundary` has been renamed to `boundary_orthogonalization`.
+
         Raises:
             NotImplementedError: If the chosen orthogonalization method
                 is not implemented.
@@ -308,6 +311,9 @@ class MatrixWaverec3(object):
             boundary_orthogonalization: The method used to orthogonalize
                 boundary filters, see :data:`ptwt.constants.OrthogonalizeMethod`.
                 Defaults to 'qr'.
+
+        .. versionchanged:: 1.10
+            The argument `boundary` has been renamed to `boundary_orthogonalization`.
 
         Raises:
             NotImplementedError: If the selected `boundary` mode is not supported.

--- a/src/ptwt/matmul_transform_3.py
+++ b/src/ptwt/matmul_transform_3.py
@@ -56,13 +56,13 @@ def _matrix_pad_3(
 class MatrixWavedec3(object):
     """Compute 3d separable transforms."""
 
-    @_deprecated_alias(boundary="boundary_orthogonalization")
+    @_deprecated_alias(boundary="orthogonalization")
     def __init__(
         self,
         wavelet: Union[Wavelet, str],
         level: Optional[int] = None,
         axes: tuple[int, int, int] = (-3, -2, -1),
-        boundary_orthogonalization: OrthogonalizeMethod = "qr",
+        orthogonalization: OrthogonalizeMethod = "qr",
         odd_coeff_padding_mode: BoundaryMode = "zero",
     ):
         """Create a *separable* three-dimensional fast boundary wavelet transform.
@@ -77,7 +77,7 @@ class MatrixWavedec3(object):
                 for possible choices.
             level (int, optional): The desired decomposition level.
                 Defaults to None.
-            boundary_orthogonalization: The method used to orthogonalize
+            orthogonalization: The method used to orthogonalize
                 boundary filters, see :data:`ptwt.constants.OrthogonalizeMethod`.
                 Defaults to 'qr'.
             odd_coeff_padding_mode: The constructed FWT matrices require inputs
@@ -87,7 +87,7 @@ class MatrixWavedec3(object):
                 Defaults to 'zero'.
 
         .. versionchanged:: 1.10
-            The argument `boundary` has been renamed to `boundary_orthogonalization`.
+            The argument `boundary` has been renamed to `orthogonalization`.
 
         Raises:
             NotImplementedError: If the chosen orthogonalization method
@@ -97,7 +97,7 @@ class MatrixWavedec3(object):
         """
         self.wavelet = _as_wavelet(wavelet)
         self.level = level
-        self.boundary_orthogonalization = boundary_orthogonalization
+        self.orthogonalization = orthogonalization
         self.odd_coeff_padding_mode = odd_coeff_padding_mode
         if len(axes) != 3:
             raise ValueError("3D transforms work with three axes.")
@@ -107,7 +107,7 @@ class MatrixWavedec3(object):
         self.input_signal_shape: Optional[tuple[int, int, int]] = None
         self.fwt_matrix_list: list[list[torch.Tensor]] = []
 
-        if not _is_boundary_mode_supported(self.boundary_orthogonalization):
+        if not _is_boundary_mode_supported(self.orthogonalization):
             raise NotImplementedError
         if self.wavelet.dec_len != self.wavelet.rec_len:
             raise ValueError("All filters must have the same length")
@@ -155,7 +155,7 @@ class MatrixWavedec3(object):
             matrix_construction_fun = partial(
                 construct_boundary_a,
                 wavelet=self.wavelet,
-                boundary_orthogonalization=self.boundary_orthogonalization,
+                orthogonalization=self.orthogonalization,
                 device=device,
                 dtype=dtype,
             )
@@ -292,12 +292,12 @@ class MatrixWavedec3(object):
 class MatrixWaverec3(object):
     """Reconstruct a signal from 3d-separable-fwt coefficients."""
 
-    @_deprecated_alias(boundary="boundary_orthogonalization")
+    @_deprecated_alias(boundary="orthogonalization")
     def __init__(
         self,
         wavelet: Union[Wavelet, str],
         axes: tuple[int, int, int] = (-3, -2, -1),
-        boundary_orthogonalization: OrthogonalizeMethod = "qr",
+        orthogonalization: OrthogonalizeMethod = "qr",
     ):
         """Compute a three-dimensional separable boundary wavelet synthesis transform.
 
@@ -308,12 +308,12 @@ class MatrixWaverec3(object):
                 for possible choices.
             axes (tuple[int, int, int]): Transform these axes instead of the
                 last three. Defaults to (-3, -2, -1).
-            boundary_orthogonalization: The method used to orthogonalize
+            orthogonalization: The method used to orthogonalize
                 boundary filters, see :data:`ptwt.constants.OrthogonalizeMethod`.
                 Defaults to 'qr'.
 
         .. versionchanged:: 1.10
-            The argument `boundary` has been renamed to `boundary_orthogonalization`.
+            The argument `boundary` has been renamed to `orthogonalization`.
 
         Raises:
             NotImplementedError: If the selected `boundary` mode is not supported.
@@ -325,12 +325,12 @@ class MatrixWaverec3(object):
         else:
             _check_axes_argument(list(axes))
             self.axes = axes
-        self.boundary_orthogonalization = boundary_orthogonalization
+        self.orthogonalization = orthogonalization
         self.ifwt_matrix_list: list[list[torch.Tensor]] = []
         self.input_signal_shape: Optional[tuple[int, int, int]] = None
         self.level: Optional[int] = None
 
-        if not _is_boundary_mode_supported(self.boundary_orthogonalization):
+        if not _is_boundary_mode_supported(self.orthogonalization):
             raise NotImplementedError
 
         if self.wavelet.dec_len != self.wavelet.rec_len:
@@ -375,7 +375,7 @@ class MatrixWaverec3(object):
             matrix_construction_fun = partial(
                 construct_boundary_s,
                 wavelet=self.wavelet,
-                boundary_orthogonalization=self.boundary_orthogonalization,
+                orthogonalization=self.orthogonalization,
                 device=device,
                 dtype=dtype,
             )

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -12,7 +12,7 @@ import numpy as np
 import pywt
 import torch
 
-from ._util import Wavelet, _as_wavelet, _swap_axes, _undo_swap_axes
+from ._util import Wavelet, _as_wavelet, _deprecated_alias, _swap_axes, _undo_swap_axes
 from .constants import (
     ExtendedBoundaryMode,
     OrthogonalizeMethod,
@@ -54,6 +54,7 @@ def _wpfreq(fs: float, level: int) -> list[float]:
 class WaveletPacket(BaseDict):
     """Implements a single-dimensional wavelet packets analysis transform."""
 
+    @_deprecated_alias(boundary_orthogonalization="orthogonalization")
     def __init__(
         self,
         data: Optional[torch.Tensor],
@@ -90,6 +91,10 @@ class WaveletPacket(BaseDict):
                 to use in the sparse matrix backend,
                 see :data:`ptwt.constants.OrthogonalizeMethod`.
                 Only used if `mode` equals 'boundary'. Defaults to 'qr'.
+
+        .. versionchanged:: 1.10
+            The argument `boundary_orthogonalization` has been renamed to
+            `orthogonalization`.
 
         Example:
             >>> import torch, pywt, ptwt
@@ -338,6 +343,7 @@ class WaveletPacket2D(BaseDict):
     https://github.com/v0lta/PyTorch-Wavelet-Toolbox/tree/main/examples/deepfake_analysis
     """
 
+    @_deprecated_alias(boundary_orthogonalization="orthogonalization")
     def __init__(
         self,
         data: Optional[torch.Tensor],
@@ -378,6 +384,10 @@ class WaveletPacket2D(BaseDict):
                 Only used if `mode` equals 'boundary'. Defaults to 'qr'.
             separable (bool): If true, a separable transform is performed,
                 i.e. each image axis is transformed separately. Defaults to False.
+
+        .. versionchanged:: 1.10
+            The argument `boundary_orthogonalization` has been renamed to
+            `orthogonalization`.
         """
         self.wavelet = _as_wavelet(wavelet)
         self.mode = mode

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -84,7 +84,7 @@ class WaveletPacket(BaseDict):
                 The highest decomposition level to compute. If None, the maximum level
                 is determined from the input data shape. Defaults to None.
             axis (int): The axis to transform. Defaults to -1.
-            boundary_orthogonalization : The orthogonalization method
+            boundary_orthogonalization: The orthogonalization method
                 to use in the sparse matrix backend,
                 see :data:`ptwt.constants.OrthogonalizeMethod`.
                 Only used if `mode` equals 'boundary'. Defaults to 'qr'.
@@ -108,7 +108,7 @@ class WaveletPacket(BaseDict):
         """
         self.wavelet = _as_wavelet(wavelet)
         self.mode = mode
-        self.boundary = boundary_orthogonalization
+        self.boundary_orthogonalization = boundary_orthogonalization
         self._matrix_wavedec_dict: dict[int, MatrixWavedec] = {}
         self._matrix_waverec_dict: dict[int, MatrixWaverec] = {}
         self.maxlevel: Optional[int] = None
@@ -183,7 +183,10 @@ class WaveletPacket(BaseDict):
         if self.mode == "boundary":
             if length not in self._matrix_wavedec_dict.keys():
                 self._matrix_wavedec_dict[length] = MatrixWavedec(
-                    self.wavelet, level=1, boundary=self.boundary, axis=self.axis
+                    self.wavelet,
+                    level=1,
+                    boundary_orthogonalization=self.boundary_orthogonalization,
+                    axis=self.axis,
                 )
             return self._matrix_wavedec_dict[length]
         else:
@@ -198,7 +201,9 @@ class WaveletPacket(BaseDict):
         if self.mode == "boundary":
             if length not in self._matrix_waverec_dict.keys():
                 self._matrix_waverec_dict[length] = MatrixWaverec(
-                    self.wavelet, boundary=self.boundary, axis=self.axis
+                    self.wavelet,
+                    boundary_orthogonalization=self.boundary_orthogonalization,
+                    axis=self.axis,
                 )
             return self._matrix_waverec_dict[length]
         else:
@@ -328,7 +333,7 @@ class WaveletPacket2D(BaseDict):
         """
         self.wavelet = _as_wavelet(wavelet)
         self.mode = mode
-        self.boundary = boundary_orthogonalization
+        self.boundary_orthogonalization = boundary_orthogonalization
         self.separable = separable
         self.matrix_wavedec2_dict: dict[tuple[int, ...], MatrixWavedec2] = {}
         self.matrix_waverec2_dict: dict[tuple[int, ...], MatrixWaverec2] = {}
@@ -413,7 +418,7 @@ class WaveletPacket2D(BaseDict):
                     self.wavelet,
                     level=1,
                     axes=self.axes,
-                    boundary=self.boundary,
+                    boundary_orthogonalization=self.boundary_orthogonalization,
                     separable=self.separable,
                 )
             fun = self.matrix_wavedec2_dict[shape]
@@ -442,7 +447,7 @@ class WaveletPacket2D(BaseDict):
                 self.matrix_waverec2_dict[shape] = MatrixWaverec2(
                     self.wavelet,
                     axes=self.axes,
-                    boundary=self.boundary,
+                    boundary_orthogonalization=self.boundary_orthogonalization,
                     separable=self.separable,
                 )
             return self.matrix_waverec2_dict[shape]

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -61,7 +61,7 @@ class WaveletPacket(BaseDict):
         mode: ExtendedBoundaryMode = "reflect",
         maxlevel: Optional[int] = None,
         axis: int = -1,
-        boundary_orthogonalization: OrthogonalizeMethod = "qr",
+        orthogonalization: OrthogonalizeMethod = "qr",
     ) -> None:
         """Create a wavelet packet decomposition object.
 
@@ -86,7 +86,7 @@ class WaveletPacket(BaseDict):
                 The highest decomposition level to compute. If None, the maximum level
                 is determined from the input data shape. Defaults to None.
             axis (int): The axis to transform. Defaults to -1.
-            boundary_orthogonalization: The orthogonalization method
+            orthogonalization: The orthogonalization method
                 to use in the sparse matrix backend,
                 see :data:`ptwt.constants.OrthogonalizeMethod`.
                 Only used if `mode` equals 'boundary'. Defaults to 'qr'.
@@ -107,7 +107,7 @@ class WaveletPacket(BaseDict):
         """
         self.wavelet = _as_wavelet(wavelet)
         self.mode = mode
-        self.boundary_orthogonalization = boundary_orthogonalization
+        self.orthogonalization = orthogonalization
         self._matrix_wavedec_dict: dict[int, MatrixWavedec] = {}
         self._matrix_waverec_dict: dict[int, MatrixWaverec] = {}
         self.maxlevel: Optional[int] = None
@@ -219,7 +219,7 @@ class WaveletPacket(BaseDict):
                 self._matrix_wavedec_dict[length] = MatrixWavedec(
                     self.wavelet,
                     level=1,
-                    boundary_orthogonalization=self.boundary_orthogonalization,
+                    orthogonalization=self.orthogonalization,
                     axis=self.axis,
                 )
             return self._matrix_wavedec_dict[length]
@@ -236,7 +236,7 @@ class WaveletPacket(BaseDict):
             if length not in self._matrix_waverec_dict.keys():
                 self._matrix_waverec_dict[length] = MatrixWaverec(
                     self.wavelet,
-                    boundary_orthogonalization=self.boundary_orthogonalization,
+                    orthogonalization=self.orthogonalization,
                     axis=self.axis,
                 )
             return self._matrix_waverec_dict[length]
@@ -345,7 +345,7 @@ class WaveletPacket2D(BaseDict):
         mode: ExtendedBoundaryMode = "reflect",
         maxlevel: Optional[int] = None,
         axes: tuple[int, int] = (-2, -1),
-        boundary_orthogonalization: OrthogonalizeMethod = "qr",
+        orthogonalization: OrthogonalizeMethod = "qr",
         separable: bool = False,
     ) -> None:
         """Create a 2D-Wavelet packet tree.
@@ -372,7 +372,7 @@ class WaveletPacket2D(BaseDict):
                 is determined from the input data shape. Defaults to None.
             axes ([int, int], optional): The tensor axes that should be transformed.
                 Defaults to (-2, -1).
-            boundary_orthogonalization : The orthogonalization method
+            orthogonalization : The orthogonalization method
                 to use in the sparse matrix backend,
                 see :data:`ptwt.constants.OrthogonalizeMethod`.
                 Only used if `mode` equals 'boundary'. Defaults to 'qr'.
@@ -381,7 +381,7 @@ class WaveletPacket2D(BaseDict):
         """
         self.wavelet = _as_wavelet(wavelet)
         self.mode = mode
-        self.boundary_orthogonalization = boundary_orthogonalization
+        self.orthogonalization = orthogonalization
         self.separable = separable
         self.matrix_wavedec2_dict: dict[tuple[int, ...], MatrixWavedec2] = {}
         self.matrix_waverec2_dict: dict[tuple[int, ...], MatrixWaverec2] = {}
@@ -508,7 +508,7 @@ class WaveletPacket2D(BaseDict):
                     self.wavelet,
                     level=1,
                     axes=self.axes,
-                    boundary_orthogonalization=self.boundary_orthogonalization,
+                    orthogonalization=self.orthogonalization,
                     separable=self.separable,
                 )
             fun = self.matrix_wavedec2_dict[shape]
@@ -537,7 +537,7 @@ class WaveletPacket2D(BaseDict):
                 self.matrix_waverec2_dict[shape] = MatrixWaverec2(
                     self.wavelet,
                     axes=self.axes,
-                    boundary_orthogonalization=self.boundary_orthogonalization,
+                    orthogonalization=self.orthogonalization,
                     separable=self.separable,
                 )
             return self.matrix_waverec2_dict[shape]

--- a/src/ptwt/packets.py
+++ b/src/ptwt/packets.py
@@ -12,7 +12,14 @@ import numpy as np
 import pywt
 import torch
 
-from ._util import Wavelet, _as_wavelet, _deprecated_alias, _swap_axes, _undo_swap_axes
+from ._util import (
+    Wavelet,
+    _as_wavelet,
+    _deprecated_alias,
+    _is_orthogonalize_method_supported,
+    _swap_axes,
+    _undo_swap_axes,
+)
 from .constants import (
     ExtendedBoundaryMode,
     OrthogonalizeMethod,
@@ -96,6 +103,10 @@ class WaveletPacket(BaseDict):
             The argument `boundary_orthogonalization` has been renamed to
             `orthogonalization`.
 
+        Raises:
+            NotImplementedError: If the selected `orthogonalization` mode
+                is not supported.
+
         Example:
             >>> import torch, pywt, ptwt
             >>> import numpy as np
@@ -119,6 +130,9 @@ class WaveletPacket(BaseDict):
         self.axis = axis
 
         self._filter_keys = {"a", "d"}
+
+        if not _is_orthogonalize_method_supported(self.orthogonalization):
+            raise NotImplementedError
 
         if data is not None:
             self.transform(data, maxlevel)
@@ -388,6 +402,10 @@ class WaveletPacket2D(BaseDict):
         .. versionchanged:: 1.10
             The argument `boundary_orthogonalization` has been renamed to
             `orthogonalization`.
+
+        Raises:
+            NotImplementedError: If the selected `orthogonalization` mode
+                is not supported.
         """
         self.wavelet = _as_wavelet(wavelet)
         self.mode = mode
@@ -397,6 +415,9 @@ class WaveletPacket2D(BaseDict):
         self.matrix_waverec2_dict: dict[tuple[int, ...], MatrixWaverec2] = {}
         self.axes = axes
         self._filter_keys = {"a", "h", "v", "d"}
+
+        if not _is_orthogonalize_method_supported(self.orthogonalization):
+            raise NotImplementedError
 
         self.maxlevel: Optional[int] = None
         if data is not None:

--- a/tests/test_matrix_fwt.py
+++ b/tests/test_matrix_fwt.py
@@ -140,9 +140,9 @@ def test_boundary_transform_1d(
     """Ensure matrix fwt reconstructions are pywt compatible."""
     data_torch = torch.from_numpy(data.astype(np.float64))
     wavelet = pywt.Wavelet(wavelet_str)
-    matrix_wavedec = MatrixWavedec(wavelet, level=level, boundary=boundary)
+    matrix_wavedec = MatrixWavedec(wavelet, level=level, boundary_orthogonalization=boundary)
     coeffs = matrix_wavedec(data_torch)
-    matrix_waverec = MatrixWaverec(wavelet, boundary=boundary)
+    matrix_waverec = MatrixWaverec(wavelet, boundary_orthogonalization=boundary)
     rec = matrix_waverec(coeffs)
     rec_pywt = pywt.waverec(
         pywt.wavedec(data_torch.numpy(), wavelet, mode="zero"), wavelet
@@ -172,9 +172,9 @@ def test_matrix_transform_1d_rebuild(
     """Ensure matrix fwt reconstructions are pywt compatible."""
     data_list = [np.random.randn(18), np.random.randn(21)]
     wavelet = pywt.Wavelet(wavelet_str)
-    matrix_waverec = MatrixWaverec(wavelet, boundary=boundary)
+    matrix_waverec = MatrixWaverec(wavelet, boundary_orthogonalization=boundary)
     for level in [2, 1]:
-        matrix_wavedec = MatrixWavedec(wavelet, level=level, boundary=boundary)
+        matrix_wavedec = MatrixWavedec(wavelet, level=level, boundary_orthogonalization=boundary)
         for data in data_list:
             data_torch = torch.from_numpy(data.astype(np.float64))
             coeffs = matrix_wavedec(data_torch)

--- a/tests/test_matrix_fwt.py
+++ b/tests/test_matrix_fwt.py
@@ -140,7 +140,9 @@ def test_boundary_transform_1d(
     """Ensure matrix fwt reconstructions are pywt compatible."""
     data_torch = torch.from_numpy(data.astype(np.float64))
     wavelet = pywt.Wavelet(wavelet_str)
-    matrix_wavedec = MatrixWavedec(wavelet, level=level, boundary_orthogonalization=boundary)
+    matrix_wavedec = MatrixWavedec(
+        wavelet, level=level, boundary_orthogonalization=boundary
+    )
     coeffs = matrix_wavedec(data_torch)
     matrix_waverec = MatrixWaverec(wavelet, boundary_orthogonalization=boundary)
     rec = matrix_waverec(coeffs)
@@ -174,7 +176,9 @@ def test_matrix_transform_1d_rebuild(
     wavelet = pywt.Wavelet(wavelet_str)
     matrix_waverec = MatrixWaverec(wavelet, boundary_orthogonalization=boundary)
     for level in [2, 1]:
-        matrix_wavedec = MatrixWavedec(wavelet, level=level, boundary_orthogonalization=boundary)
+        matrix_wavedec = MatrixWavedec(
+            wavelet, level=level, boundary_orthogonalization=boundary
+        )
         for data in data_list:
             data_torch = torch.from_numpy(data.astype(np.float64))
             coeffs = matrix_wavedec(data_torch)

--- a/tests/test_matrix_fwt.py
+++ b/tests/test_matrix_fwt.py
@@ -141,10 +141,10 @@ def test_boundary_transform_1d(
     data_torch = torch.from_numpy(data.astype(np.float64))
     wavelet = pywt.Wavelet(wavelet_str)
     matrix_wavedec = MatrixWavedec(
-        wavelet, level=level, boundary_orthogonalization=boundary
+        wavelet, level=level, orthogonalization=boundary
     )
     coeffs = matrix_wavedec(data_torch)
-    matrix_waverec = MatrixWaverec(wavelet, boundary_orthogonalization=boundary)
+    matrix_waverec = MatrixWaverec(wavelet, orthogonalization=boundary)
     rec = matrix_waverec(coeffs)
     rec_pywt = pywt.waverec(
         pywt.wavedec(data_torch.numpy(), wavelet, mode="zero"), wavelet
@@ -174,10 +174,10 @@ def test_matrix_transform_1d_rebuild(
     """Ensure matrix fwt reconstructions are pywt compatible."""
     data_list = [np.random.randn(18), np.random.randn(21)]
     wavelet = pywt.Wavelet(wavelet_str)
-    matrix_waverec = MatrixWaverec(wavelet, boundary_orthogonalization=boundary)
+    matrix_waverec = MatrixWaverec(wavelet, orthogonalization=boundary)
     for level in [2, 1]:
         matrix_wavedec = MatrixWavedec(
-            wavelet, level=level, boundary_orthogonalization=boundary
+            wavelet, level=level, orthogonalization=boundary
         )
         for data in data_list:
             data_torch = torch.from_numpy(data.astype(np.float64))

--- a/tests/test_matrix_fwt.py
+++ b/tests/test_matrix_fwt.py
@@ -140,9 +140,7 @@ def test_boundary_transform_1d(
     """Ensure matrix fwt reconstructions are pywt compatible."""
     data_torch = torch.from_numpy(data.astype(np.float64))
     wavelet = pywt.Wavelet(wavelet_str)
-    matrix_wavedec = MatrixWavedec(
-        wavelet, level=level, orthogonalization=boundary
-    )
+    matrix_wavedec = MatrixWavedec(wavelet, level=level, orthogonalization=boundary)
     coeffs = matrix_wavedec(data_torch)
     matrix_waverec = MatrixWaverec(wavelet, orthogonalization=boundary)
     rec = matrix_waverec(coeffs)
@@ -176,9 +174,7 @@ def test_matrix_transform_1d_rebuild(
     wavelet = pywt.Wavelet(wavelet_str)
     matrix_waverec = MatrixWaverec(wavelet, orthogonalization=boundary)
     for level in [2, 1]:
-        matrix_wavedec = MatrixWavedec(
-            wavelet, level=level, orthogonalization=boundary
-        )
+        matrix_wavedec = MatrixWavedec(wavelet, level=level, orthogonalization=boundary)
         for data in data_list:
             data_torch = torch.from_numpy(data.astype(np.float64))
             coeffs = matrix_wavedec(data_torch)
@@ -245,4 +241,4 @@ def test_axis_1d(axis: int) -> None:
 def test_deprecation() -> None:
     """Ensure the deprecation warning is raised."""
     with pytest.warns(DeprecationWarning):
-        MatrixWavedec("haar", 3, boundary='qr')
+        MatrixWavedec("haar", 3, boundary="qr")

--- a/tests/test_matrix_fwt.py
+++ b/tests/test_matrix_fwt.py
@@ -240,3 +240,9 @@ def test_axis_1d(axis: int) -> None:
 
     rec = matrix_waverec(coeff)
     assert np.allclose(rec, data)
+
+
+def test_deprecation() -> None:
+    """Ensure the deprecation warning is raised."""
+    with pytest.warns(DeprecationWarning):
+        MatrixWavedec("haar", 3, boundary='qr')

--- a/tests/test_matrix_fwt_2.py
+++ b/tests/test_matrix_fwt_2.py
@@ -259,3 +259,9 @@ def test_axes_2d(axes: tuple[int, int]) -> None:
 
     rec = matrix_waverec2(coeff)
     assert np.allclose(rec, data)
+
+
+def test_deprecation() -> None:
+    """Ensure the deprecation warning is raised."""
+    with pytest.warns(DeprecationWarning):
+        MatrixWavedec2("haar", 3, boundary="qr")

--- a/tests/test_matrix_fwt_2.py
+++ b/tests/test_matrix_fwt_2.py
@@ -8,6 +8,7 @@ import pywt
 import scipy.signal
 import torch
 
+from ptwt.constants import BoundaryMode
 from ptwt.conv_transform import _flatten_2d_coeff_lst
 from ptwt.matmul_transform import BaseMatrixWaveDec, MatrixWavedec, MatrixWaverec
 from ptwt.matmul_transform_2 import (
@@ -86,15 +87,24 @@ def test_matrix_analysis_fwt_2d_haar(size: tuple[int, int], level: int) -> None:
 )
 @pytest.mark.parametrize("level", [1, 2, 3, None])
 @pytest.mark.parametrize("separable", [False, True])
+@pytest.mark.parametrize(
+    "mode", ["reflect", "zero", "constant", "periodic", "symmetric"]
+)
 def test_boundary_matrix_fwt_2d(
-    wavelet_str: str, size: tuple[int, int], level: int, separable: bool
+    wavelet_str: str,
+    size: tuple[int, int],
+    level: int,
+    separable: bool,
+    mode: BoundaryMode,
 ) -> None:
     """Ensure the boundary matrix fwt is invertable."""
     face = np.mean(
         scipy.datasets.face()[256 : (256 + size[0]), 256 : (256 + size[1])], -1
     ).astype(np.float64)
     wavelet = pywt.Wavelet(wavelet_str)
-    matrixfwt = MatrixWavedec2(wavelet, level=level, separable=separable)
+    matrixfwt = MatrixWavedec2(
+        wavelet, level=level, separable=separable, odd_coeff_padding_mode=mode
+    )
     mat_coeff = matrixfwt(torch.from_numpy(face))
     matrixifwt = MatrixWaverec2(wavelet, separable=separable)
     reconstruction = matrixifwt(mat_coeff).squeeze(0)

--- a/tests/test_matrix_fwt_3.py
+++ b/tests/test_matrix_fwt_3.py
@@ -116,3 +116,9 @@ def test_axes_arg_matrix_3d(axes: list[int], level: int) -> None:
     # test inversion
     rec = MatrixWaverec3(wavelet, axes=axes)(ptwc)
     assert np.allclose(data, rec.numpy())
+
+
+def test_deprecation() -> None:
+    """Ensure the deprecation warning is raised."""
+    with pytest.warns(DeprecationWarning):
+        MatrixWavedec3("haar", 3, boundary="qr")

--- a/tests/test_matrix_fwt_3.py
+++ b/tests/test_matrix_fwt_3.py
@@ -7,6 +7,7 @@ import pytest
 import pywt
 import torch
 
+from ptwt.constants import BoundaryMode
 from ptwt.matmul_transform import construct_boundary_a
 from ptwt.matmul_transform_3 import MatrixWavedec3, MatrixWaverec3
 from ptwt.sparse_math import _batch_dim_mm
@@ -75,13 +76,16 @@ def test_boundary_wavedec3_level1_haar(shape: tuple[int, int, int]) -> None:
 @pytest.mark.parametrize(
     "shape", [(31, 32, 33), (63, 35, 32), (32, 62, 31), (32, 32, 64)]
 )
+@pytest.mark.parametrize(
+    "mode", ["reflect", "zero", "constant", "periodic", "symmetric"]
+)
 def test_boundary_wavedec3_inverse(
-    level: Optional[int], shape: tuple[int, int, int]
+    level: Optional[int], shape: tuple[int, int, int], mode: BoundaryMode
 ) -> None:
     """Test the 3d matrix wavedec and the padding for odd axes."""
     batch_size = 1
     test_data = torch.rand(batch_size, shape[0], shape[1], shape[2]).type(torch.float64)
-    ptwtres = MatrixWavedec3("haar", level)(test_data)
+    ptwtres = MatrixWavedec3("haar", level, odd_coeff_padding_mode=mode)(test_data)
     rec = MatrixWaverec3("haar")(ptwtres)
     assert np.allclose(
         test_data.numpy(), rec[:, : shape[0], : shape[1], : shape[2]].numpy()

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -607,3 +607,11 @@ def test_partial_reconstruction() -> None:
     ptwp.reconstruct()
 
     assert np.allclose(signal2, ptwp[""].numpy()[:16])
+
+
+def test_deprecation() -> None:
+    """Ensure the deprecation warning is raised."""
+    with pytest.warns(DeprecationWarning):
+        WaveletPacket(None, "haar", boundary_orthogonalization="qr")
+    with pytest.warns(DeprecationWarning):
+        WaveletPacket2D(None, "haar", boundary_orthogonalization="qr")


### PR DESCRIPTION
Addresses #90.

In sparse-matrix based wavelet decompositions, we require all transformed approximations coefficients to be of even length. This is enforced by padding a single value along all axes with odd lengths.

Currently, this is always done by zero padding. This PR adds the option to specify a different padding type. 

This also makes it easier to document the padding behaviour.