### PR TITLE
Move from mypy master to PyPI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ tests =
     # pooch is an optional scipy dependency for getting datasets
     pooch
 typing =
-    mypy @ git+https://github.com/python/mypy
+    mypy>=1.11
     # needed otherwise pytest decorators don't get typed properly
     pytest
 examples =


### PR DESCRIPTION
As [mypy 1.11 is released](https://mypy-lang.blogspot.com/2024/07/mypy-111-released.html) we no longer need to install directly from the git master but can install from PyPI as usual.

This addresses #89.