### PR TITLE
Add py.typed file to support type checking. (PEP 561)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,9 @@ typing =
 examples =
     matplotlib
 
+[options.package_data]
+ptwt = py.typed
+
 ##########################
 # Darglint Configuration #
 ##########################


### PR DESCRIPTION
## Description
 This PR adds a `py.typed` marker file and includes it in the package metadata to support [PEP 561](https://peps.python.org/pep-0561/). This enables external tools such as `mypy` to recognize and make use of the inline type hints defined in the `ptwt` package.

## Changes made:
- Added `py.typed` file to indicate that the package supports type hints.
- Updated `setup.cfg` to include `py.typed` under `[options.package_data]`.

## Reason
Without the `py.typed` marker file, tools like `mypy` cannot detect type hints in this package even though type annotations are present in the source. 