### PR TITLE
Add reconstruction 2D and 3D modules

### DIFF
--- a/examples/network_compression/wavelet_linear.py
+++ b/examples/network_compression/wavelet_linear.py
@@ -227,7 +227,7 @@ class WaveletReconstruction3d(
         scales: int,
         coefficient_lengths: list[int],
         wavelet: WaveletFilter,
-        axis: tuple[int, int] | None = None,
+        axis: tuple[int, int, int] | None = None,
     ) -> None:
         super().__init__(
             scales=scales,


### PR DESCRIPTION
This PR makes the WaveletReconstruction1D module a bit more generic, then adds stub implementations for the 2D and 3D counterparts

@v0lta this needs your help to implement `get_coefficients()` for 2D and 3D

I didn't want to make a big diff so these aren't in the main module yet, but in a follow-up, they will go there.